### PR TITLE
o1-preview and o1-mini

### DIFF
--- a/core/js/gpt-core.js
+++ b/core/js/gpt-core.js
@@ -298,6 +298,13 @@ function trboSend() {
     var cStoredMessages = localStorage.getItem("messages");
     kMessages = cStoredMessages ? JSON.parse(cStoredMessages) : [];
 
+        // Exclude messages with the "developer" role see 
+        // https://github.com/appatalks/chatgpt-html/issues/63#issuecomment-2492821202 
+        if (sModel === 'o1-preview' || sModel === 'o1-mini') {
+          kMessages = kMessages.filter(msg => msg.role === 'user' || msg.role === 'assistant');
+          dTemperature = 1;
+        }
+	
     // API Payload
     var data = {
         model: sModel,


### PR DESCRIPTION

This pull request includes an important change to the `trboSend` function in the `core/js/gpt-core.js` file to filter out messages with the "developer" role for specific models.

Filtering messages:

* [`core/js/gpt-core.js`](diffhunk://#diff-1b7b7fc3cf1cc46d5e9a67f4c3ee3b698623ad1a137d83fad83c9e8ba4abe583R301-R307): Modified the `trboSend` function to exclude messages with the "developer" role when the model is either 'o1-preview' or 'o1-mini'. This change ensures that only messages from users or assistants are included in these cases.