### PR TITLE
update to openllm references

### DIFF
--- a/core/js/lm-studio.js
+++ b/core/js/lm-studio.js
@@ -5,7 +5,7 @@ function lmsSend() {
     // Remove occurrences of specific syntax from the txtMsg element
     txtMsg.innerHTML = txtMsg.innerHTML.replace(/<div[^>]*>.*<\/div>/g, '');
 
-    let openAIMessages = [
+    let openLLMessages = [
         {
             "role": "system",
             "content": selPers.value + " Images can be shown with this tag: [Image of <Description>]. " + dateContents
@@ -17,9 +17,9 @@ function lmsSend() {
     ];
 
     // Check if there are messages stored in local storage
-    const storedOpenAIMessages = localStorage.getItem("openAIMessages");
-    if (storedOpenAIMessages) {
-        openAIMessages = JSON.parse(storedOpenAIMessages);
+    const storedopenLLMessages = localStorage.getItem("openLLMessages");
+    if (storedopenLLMessages) {
+        openLLMessages = JSON.parse(storedopenLLMessages);
     }
 
     const sQuestion = document.getElementById("txtMsg").innerHTML.replace(/<br>/g, "\n").replace(/<[^>]+>/g, "").trim();
@@ -42,7 +42,7 @@ function lmsSend() {
         },
         body: JSON.stringify({
             model: "granite-3.1-8b-instruct", // Replace with your actual local model identifier
-            messages: openAIMessages.concat([
+            messages: openLLMessages.concat([
                 { role: "user", content: sQuestion }
             ]),
             temperature: 0.7, // Adjust as needed
@@ -69,9 +69,9 @@ function lmsSend() {
             }
 
             // Update conversation history
-            openAIMessages.push({ role: "user", content: sQuestion });
-            openAIMessages.push({ role: "assistant", content: candidate });
-            localStorage.setItem("openAIMessages", JSON.stringify(openAIMessages));
+            openLLMessages.push({ role: "user", content: sQuestion });
+            openLLMessages.push({ role: "assistant", content: candidate });
+            localStorage.setItem("openLLMessages", JSON.stringify(openLLMessages));
 
             // Check the state of the checkbox and have fun
             const checkbox = document.getElementById("autoSpeak");


### PR DESCRIPTION
Didn't want to confuse openAIMessages with OpenAI, so changing to openLLM to better fit case.

This pull request includes changes to the `lmsSend` function in the `core/js/lm-studio.js` file to update variable names and local storage keys from "openAIMessages" to "openLLMessages". These changes ensure that the code references the correct variable names and keys for the updated messaging system.

Key changes include:

* Updated the variable name from `openAIMessages` to `openLLMessages` for the initial message array.
* Changed the local storage key from "openAIMessages" to "openLLMessages" and updated the corresponding variable name.
* Modified the `messages` property in the request body to use `openLLMessages` instead of `openAIMessages`.
* Updated the conversation history logic to use `openLLMessages` for storing and retrieving messages.