### PR TITLE
o3-mini support Added

### DIFF
--- a/core/js/gpt-core.js
+++ b/core/js/gpt-core.js
@@ -264,6 +264,11 @@ function trboSend() {
 		        presence_penalty: cPresence_penalty,
 		        stop: hStop
 		    }
+		    // If using the o3-mini model, add the reasoning_effort parameter (low, medium, high)
+		    if (sModel === "o3-mini") {
+  		      data.reasoning_effort = "high";
+		    }   
+		    // Send Payload		      
 		    oHttp.send(JSON.stringify(data));
 
 		// Check if imgSrcGlobal is not empty or undefined
@@ -315,10 +320,14 @@ function trboSend() {
         presence_penalty: cPresence_penalty,
 	stop: hStop
     }
+    // If using the o3-mini model, add the reasoning_effort parameter (low, medium, high)
+    if (sModel === "o3-mini") {
+      data.reasoning_effort = "medium";
+    }   
 
     // Sending API Payload
     oHttp.send(JSON.stringify(data));
-    // console.log("gpt-core.js Line 314" + JSON.stringify(data));
+    // console.log("gpt-core.js Line 330" + JSON.stringify(data));
 
     // Relay Send to Screen
 

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -69,7 +69,7 @@ function updateButton() {
     var selModel = document.getElementById("selModel");
     var btnSend = document.getElementById("btnSend");
 
-    if (selModel.value == "gpt-4o-mini" || selModel.value == "o1" || selModel.value == "o1-mini" || selModel.value == "gpt-4o" || selModel.value == "o1-preview") {
+    if (selModel.value == "gpt-4o-mini" || selModel.value == "o1" || selModel.value == "o1-mini" || selModel.value == "gpt-4o" || selModel.value == "o3-mini" || selModel.value == "o1-preview") {
         btnSend.onclick = function() {
             clearText();
             trboSend();
@@ -103,7 +103,7 @@ function sendData() {
     // Logic required for initial message
     var selModel = document.getElementById("selModel");
 
-    if (selModel.value == "gpt-4o-mini" || selModel.value == "o1" || selModel.value == "o1-mini" || selModel.value == "gpt-4o" || selModel.value == "o1-preview") {
+    if (selModel.value == "gpt-4o-mini" || selModel.value == "o1" || selModel.value == "o1-mini" || selModel.value == "gpt-4o" || selModel.value == "o3-mini" || selModel.value == "o1-preview") {
         clearText();
         trboSend();
     } else if (selModel.value == "gemini") {
@@ -265,7 +265,7 @@ function insertImage() {
               sendData();
               clearSendText();
           };
-      } else if (selModel.value == "gpt-4o" || selModel.value == "gpt-4o-mini" || selModel.value == "o1-mini") {
+      } else if (selModel.value == "gpt-4o" || selModel.value == "gpt-4o-mini" || selModel.value == "o1-mini" || selModel.value == "o3-mini") {
           sendToNative(imageData, sQuestion);
           btnSend.onclick = function() {
               updateButton();

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -258,14 +258,14 @@ function insertImage() {
 
       
       // Send to VisionAPI
-      if (selModel.value == "gpt-3.5-turbo" || selModel.value == "gpt-4-turbo-preview") {
+      if (selModel.value == "o3-mini" || selModel.value == "gpt-4-turbo-preview") {
           sendToVisionAPI(imageData);
           btnSend.onclick = function() {
               updateButton();
               sendData();
               clearSendText();
           };
-      } else if (selModel.value == "gpt-4o" || selModel.value == "gpt-4o-mini" || selModel.value == "o1-mini" || selModel.value == "o3-mini") {
+      } else if (selModel.value == "gpt-4o" || selModel.value == "gpt-4o-mini" || selModel.value == "o1-mini") {
           sendToNative(imageData, sQuestion);
           btnSend.onclick = function() {
               updateButton();

--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
       <option value="o1" title="o1">o1</option>
       <option value="o1-preview" title="o1-preview">o1-preview</option>
       <option value="o1-mini" title="o1-mini">o1-mini</option>
+      <option value="o3-mini" title="o3-mini">o3-mini</option>	    
       <option value="dall-e-3" title="Image Generation">dall-e-3</option>
       <option value="gemini" title="Google Gemini">gemini</option>
       <option value="lm-studio" title="lm-studio">lm-studio</option>


### PR DESCRIPTION
Solves https://github.com/appatalks/chatgpt-html/issues/65

> [!NOTE]
> o3-mini is rolling out in the Chat Completions API, Assistants API, and Batch API starting today to select developers in [API usage tiers 3-5⁠(opens in a new window)](https://platform.openai.com/docs/guides/rate-limits/usage-tiers#tier-3-rate-limits).

More:
https://openai.com/index/openai-o3-mini/
https://platform.openai.com/docs/models#o3-mini
https://platform.openai.com/docs/guides/reasoning

---

#### CoPilot Generated Notes

This pull request includes several changes to support the new `o3-mini` model in the `core/js/gpt-core.js` and `core/js/options.js` files, as well as an update to the model selection options in `index.html`.

### Support for `o3-mini` model:

* [`core/js/gpt-core.js`](diffhunk://#diff-1b7b7fc3cf1cc46d5e9a67f4c3ee3b698623ad1a137d83fad83c9e8ba4abe583R267-R271): Added logic to include the `reasoning_effort` parameter when using the `o3-mini` model in the `trboSend` function. [[1]](diffhunk://#diff-1b7b7fc3cf1cc46d5e9a67f4c3ee3b698623ad1a137d83fad83c9e8ba4abe583R267-R271) [[2]](diffhunk://#diff-1b7b7fc3cf1cc46d5e9a67f4c3ee3b698623ad1a137d83fad83c9e8ba4abe583R323-R330)

### Updates to model selection:

* [`core/js/options.js`](diffhunk://#diff-b041995f529832e6bf9680cb8b37cd4d0b5d8238bb6644c04a11d3a7eff8d9e2L72-R72): Updated various functions (`updateButton`, `sendData`, `insertImage`) to include the `o3-mini` model in the conditional checks for model selection. [[1]](diffhunk://#diff-b041995f529832e6bf9680cb8b37cd4d0b5d8238bb6644c04a11d3a7eff8d9e2L72-R72) [[2]](diffhunk://#diff-b041995f529832e6bf9680cb8b37cd4d0b5d8238bb6644c04a11d3a7eff8d9e2L106-R106) [[3]](diffhunk://#diff-b041995f529832e6bf9680cb8b37cd4d0b5d8238bb6644c04a11d3a7eff8d9e2L261-R261)
* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R94): Added the `o3-mini` model to the dropdown list of model options.