### PR TITLE
Update gpt-core.js - o3-mini rm temp

### DIFF
--- a/core/js/gpt-core.js
+++ b/core/js/gpt-core.js
@@ -267,6 +267,7 @@ function trboSend() {
 		    // If using the o3-mini model, add the reasoning_effort parameter (low, medium, high)
 		    if (sModel === "o3-mini") {
   		      data.reasoning_effort = "high";
+		      delete data.temperature; // Exclude temperature for o3-mini	    
 		    }   
 		    // Send Payload		      
 		    oHttp.send(JSON.stringify(data));


### PR DESCRIPTION
solves #83 

This pull request includes a small change to the `core/js/gpt-core.js` file. The change ensures that the `temperature` parameter is excluded when using the `o3-mini` model in the `trboSend` function.

* [`core/js/gpt-core.js`](diffhunk://#diff-1b7b7fc3cf1cc46d5e9a67f4c3ee3b698623ad1a137d83fad83c9e8ba4abe583R270): Added a line to delete the `temperature` parameter from the `data` object when the `sModel` is `o3-mini`.