### PR TITLE
Standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ token_cache.*
 
 # Node (if npx runs locally)
 node_modules/
+standalone/node_modules/
+standalone/dist/
+standalone/out/
+*.AppImage
 
 # Local-only agent knowledge for the maintainer (never committed).
 # Holds dev topology, cluster URLs, recurring commands, and agent playbooks

--- a/README-2.md
+++ b/README-2.md
@@ -391,6 +391,8 @@ Current state (2026-04-05):
 | Deploy bridge as systemd service | planned | Use `tools/acp_setup.sh` and `tools/acp_bridge.service` |
 | Move from split setup to single-host ACP | planned | Keep localhost fallback until this is complete |
 | Post-migration validation gate | planned | `/health` ok + AIG raw-query smoke + `tools/test_eva.py` |
+| macOS standalone build (signed + notarized) | planned | Build config exists (`npm run dist:mac` produces unsigned dmg/zip for x64+arm64). Distribution requires Apple Developer ID, hardened runtime, entitlements (likely `com.apple.security.cs.disable-library-validation` for spawning system `python3`), and `@electron/notarize` afterSign hook. Local-dev builds work today; signed distribution deferred. |
+| Windows standalone build | planned | Add `win` target (nsis or portable) to electron-builder config; same Python/Node/Copilot CLI prereqs apply. |
 
 ## Eva (AIG) — Recommended Model
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The bridge (`tools/acp_bridge.py`) exposes an OpenAI-compatible API so any clien
 - **Settings panel** with tabbed UI (General, Models, Auth, Prompts, MCP). The Models tab includes the cognitive layer toggle and per-agent prompts
 - **Inline images** — Wikimedia search or DALL-E generation
 - **LCARS and Eva themes** (Star Trek-inspired LCARS, plus a clean Eva theme with pinned footer status)
-- **Text-to-speech** — Amazon Polly and Bark TTS
+- **Text-to-speech**: OpenAI TTS by default, Browser, Bark, Amazon Polly
 - **Conversation memory** in localStorage
 - **Database seed** — `tools/eva_seed.kql` for quick public setup
 - **CI pipeline** — secret scanning, syntax checks, model routing validation

--- a/core/js/aig.js
+++ b/core/js/aig.js
@@ -108,6 +108,20 @@ async function aigSend() {
                    '/c' + (cogResult.cycles || 0) +
                    (cogDecision.reason === 'phrase' ? '/forced' : '') +
                    (actionsRun.length ? '/act' + actionsRun.length : '');
+      if (cogContent) {
+        try {
+          fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/memory/reflect', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              user_message: sQuestion,
+              assistant_message: cogContent,
+              model: cogTag
+            }),
+            signal: AbortSignal.timeout(5000)
+          }).catch(function () {});
+        } catch (_) {}
+      }
       setStatus('info', 'Eva (AIG, cognition) \u2014 ' +
                 (cogResult.implementerModel || 'implementer') +
                 '  [' + cogTag + ']');

--- a/core/js/aig.js
+++ b/core/js/aig.js
@@ -173,6 +173,8 @@ async function aigSend() {
         messages: existingMessages,
         user_message: sQuestion,
         model: (document.getElementById('selAIGBackend') || {}).value || 'gpt-4.1',
+        lmstudio_base_url: (typeof getLmStudioBaseUrl === 'function') ? getLmStudioBaseUrl() : '',
+        lmstudio_model: (typeof getLmStudioModel === 'function') ? getLmStudioModel() : '',
         github_pat: (typeof getAuthKey === 'function') ? getAuthKey('GITHUB_PAT') : ''
       })
     });

--- a/core/js/cognition.js
+++ b/core/js/cognition.js
@@ -330,6 +330,8 @@
         messages: msgs,
         user_message: taskMessage || '',
         model: model,
+        lmstudio_base_url: (typeof getLmStudioBaseUrl === 'function') ? getLmStudioBaseUrl() : '',
+        lmstudio_model: (typeof getLmStudioModel === 'function') ? getLmStudioModel() : '',
         github_pat: authPat(),
         internal: true
       })

--- a/core/js/cognition.js
+++ b/core/js/cognition.js
@@ -330,7 +330,8 @@
         messages: msgs,
         user_message: taskMessage || '',
         model: model,
-        github_pat: authPat()
+        github_pat: authPat(),
+        internal: true
       })
     });
     if (!resp.ok) {

--- a/core/js/copilot.js
+++ b/core/js/copilot.js
@@ -481,6 +481,15 @@ function setKustoSeedStatus(type, text) {
   if (text) setStatus(type === 'error' ? 'error' : 'info', text);
 }
 
+function setArtifactPurgeStatus(type, text) {
+  var statusEl = document.getElementById('mcpPurgeArtifactsStatus');
+  if (statusEl) {
+    statusEl.textContent = text || '';
+    statusEl.setAttribute('data-status', type || 'info');
+  }
+  if (text) setStatus(type === 'error' ? 'error' : 'info', text);
+}
+
 function updateKustoSeedButtonState() {
   var values = getKustoSeedValues();
   var button = document.getElementById('mcpSeedButton');
@@ -525,6 +534,36 @@ async function seedEvaSchema(clusterUrl, database, alreadyConfirmed) {
     return { ok: false, error: error };
   } finally {
     updateKustoSeedButtonState();
+  }
+}
+
+async function purgeArtifactsFromSettings() {
+  if (!confirm('Delete all generated artifacts? This cannot be undone.')) return { ok: false, skipped: true };
+
+  var button = document.getElementById('mcpPurgeArtifactsButton');
+  if (button) button.disabled = true;
+  setArtifactPurgeStatus('info', 'Purging artifacts...');
+
+  try {
+    var bridgeUrl = await detectACPBridge();
+    var response = await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/files/purge', {
+      method: 'POST',
+      body: ''
+    });
+    var data = await response.json();
+    if (!response.ok || data.status !== 'ok') {
+      var message = data && data.error && data.error.message ? data.error.message : 'Artifact purge failed';
+      setArtifactPurgeStatus('error', message);
+      return { ok: false, data: data };
+    }
+    var purged = typeof data.purged === 'number' ? data.purged : 0;
+    setArtifactPurgeStatus('info', 'Purged ' + purged + ' artifacts.');
+    return { ok: true, data: data };
+  } catch (error) {
+    setArtifactPurgeStatus('error', 'Artifact purge failed: ' + error.message);
+    return { ok: false, error: error };
+  } finally {
+    if (button) button.disabled = false;
   }
 }
 
@@ -601,6 +640,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
   var seedButton = document.getElementById('mcpSeedButton');
   if (seedButton) seedButton.addEventListener('click', seedEvaSchemaFromSettings);
+  var purgeArtifactsButton = document.getElementById('mcpPurgeArtifactsButton');
+  if (purgeArtifactsButton) purgeArtifactsButton.addEventListener('click', purgeArtifactsFromSettings);
   var seedCluster = document.getElementById('mcpKustoCluster');
   var seedDatabase = document.getElementById('mcpKustoDatabase');
   if (seedCluster) seedCluster.addEventListener('input', updateKustoSeedButtonState);

--- a/core/js/copilot.js
+++ b/core/js/copilot.js
@@ -428,6 +428,7 @@ async function applyMCPConfig() {
     var dbEl = document.getElementById('mcpKustoDatabase');
     if (clusterEl && clusterEl.value.trim()) kustoEnv.KUSTO_CLUSTER_URL = clusterEl.value.trim();
     if (dbEl && dbEl.value.trim()) kustoEnv.KUSTO_DATABASE = dbEl.value.trim();
+    if (typeof isEvaStandalone === 'function' && isEvaStandalone()) kustoEnv.KUSTO_DATABASE_LOCKED = '1';
     mcpServers['kusto-mcp-server'] = {
       command: 'python3',
       args: ['tools/kusto_mcp.py'],
@@ -451,12 +452,85 @@ async function applyMCPConfig() {
     if (resp.ok) {
       setStatus('info', 'MCP configured: ' + (data.active_servers || []).join(', '));
       refreshMCPStatus();
+      return { ok: true, data: data, bridgeUrl: bridgeUrl, mcpServers: mcpServers };
     } else {
       setStatus('error', 'MCP config error: ' + (data.error ? data.error.message : 'Unknown'));
+      return { ok: false, data: data, bridgeUrl: bridgeUrl, mcpServers: mcpServers };
     }
   } catch (e) {
     setStatus('error', 'MCP config failed: ' + e.message + ' — Is the ACP bridge running?');
+    return { ok: false, error: e, bridgeUrl: bridgeUrl, mcpServers: mcpServers };
   }
+}
+
+function getKustoSeedValues() {
+  var clusterEl = document.getElementById('mcpKustoCluster');
+  var databaseEl = document.getElementById('mcpKustoDatabase');
+  return {
+    clusterUrl: clusterEl ? clusterEl.value.trim() : '',
+    database: databaseEl ? databaseEl.value.trim() : ''
+  };
+}
+
+function setKustoSeedStatus(type, text) {
+  var statusEl = document.getElementById('mcpSeedStatus');
+  if (statusEl) {
+    statusEl.textContent = text || '';
+    statusEl.setAttribute('data-status', type || 'info');
+  }
+  if (text) setStatus(type === 'error' ? 'error' : 'info', text);
+}
+
+function updateKustoSeedButtonState() {
+  var values = getKustoSeedValues();
+  var button = document.getElementById('mcpSeedButton');
+  if (button) button.disabled = !(values.clusterUrl && values.database);
+}
+
+async function seedEvaSchema(clusterUrl, database, alreadyConfirmed) {
+  clusterUrl = (clusterUrl || '').trim();
+  database = (database || '').trim();
+  if (!clusterUrl || !database) {
+    setKustoSeedStatus('error', 'Cluster URL and database are required before seeding.');
+    return { ok: false, error: 'missing_inputs' };
+  }
+  if (!alreadyConfirmed) {
+    var confirmed = confirm('Seed Eva schema into ' + database + '? This writes starter tables and rows. Running it again can duplicate inline seed rows.');
+    if (!confirmed) return { ok: false, skipped: true };
+  }
+
+  var button = document.getElementById('mcpSeedButton');
+  if (button) button.disabled = true;
+  setKustoSeedStatus('info', 'Seeding Eva schema...');
+
+  try {
+    var bridgeUrl = await detectACPBridge();
+    var response = await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/kusto/seed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cluster_url: clusterUrl, database: database })
+    });
+    var data = await response.json();
+    if (!response.ok || !data.ok) {
+      var errors = (data && data.errors && data.errors.length) ? data.errors.slice(0, 3).join(' ') : (data.error && data.error.message ? data.error.message : 'Unknown seed error');
+      setKustoSeedStatus('error', 'Schema seed failed: ' + errors);
+      return { ok: false, data: data };
+    }
+    var message = 'Schema seed complete: ' + data.applied + ' applied, ' + data.failed + ' failed.';
+    if (data.warning) message += ' ' + data.warning;
+    setKustoSeedStatus('info', message);
+    return { ok: true, data: data };
+  } catch (error) {
+    setKustoSeedStatus('error', 'Schema seed failed: ' + error.message);
+    return { ok: false, error: error };
+  } finally {
+    updateKustoSeedButtonState();
+  }
+}
+
+async function seedEvaSchemaFromSettings() {
+  var values = getKustoSeedValues();
+  return seedEvaSchema(values.clusterUrl, values.database, false);
 }
 
 async function refreshMCPStatus() {
@@ -521,6 +595,15 @@ document.addEventListener('DOMContentLoaded', function() {
     kustoConfig.style.display = kustoToggle.checked ? 'block' : 'none';
     kustoToggle.addEventListener('change', function() {
       kustoConfig.style.display = kustoToggle.checked ? 'block' : 'none';
+      updateKustoSeedButtonState();
     });
   }
+
+  var seedButton = document.getElementById('mcpSeedButton');
+  if (seedButton) seedButton.addEventListener('click', seedEvaSchemaFromSettings);
+  var seedCluster = document.getElementById('mcpKustoCluster');
+  var seedDatabase = document.getElementById('mcpKustoDatabase');
+  if (seedCluster) seedCluster.addEventListener('input', updateKustoSeedButtonState);
+  if (seedDatabase) seedDatabase.addEventListener('input', updateKustoSeedButtonState);
+  updateKustoSeedButtonState();
 });

--- a/core/js/copilot.js
+++ b/core/js/copilot.js
@@ -18,7 +18,18 @@ function getCopilotMode(modelValue) {
   return 'models-api';
 }
 
+function isEvaStandalone() {
+  return !!(typeof window !== 'undefined' && window.evaStandalone && window.evaStandalone.isStandalone);
+}
+
+function getStandaloneACPBridgeUrl() {
+  if (!isEvaStandalone()) return '';
+  return (window.evaStandalone.acpBaseUrl || '').trim();
+}
+
 function getACPBridgeUrl() {
+  var standaloneUrl = getStandaloneACPBridgeUrl();
+  if (standaloneUrl) return standaloneUrl;
   var el = document.getElementById('txtACPBridgeUrl');
   if (el && el.value.trim() && el.value.trim() !== 'http://localhost:8888') return el.value.trim();
   var stored = localStorage.getItem('acp_bridge_url');
@@ -36,15 +47,17 @@ async function detectACPBridge() {
   var configured = getACPBridgeUrl();
   candidates.push(configured);
 
-  // Try same host as the page (for when bridge runs on the web server)
-  if (location.hostname && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
-    candidates.push(location.protocol + '//' + location.hostname + ':8888');
-    candidates.push('http://' + location.hostname + ':8888');
-  }
+  if (!isEvaStandalone()) {
+    // Try same host as the page (for when bridge runs on the web server)
+    if (location.hostname && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
+      candidates.push(location.protocol + '//' + location.hostname + ':8888');
+      candidates.push('http://' + location.hostname + ':8888');
+    }
 
-  // Localhost fallback
-  if (candidates.indexOf('http://localhost:8888') < 0) {
-    candidates.push('http://localhost:8888');
+    // Localhost fallback
+    if (candidates.indexOf('http://localhost:8888') < 0) {
+      candidates.push('http://localhost:8888');
+    }
   }
 
   // Deduplicate

--- a/core/js/lm-studio.js
+++ b/core/js/lm-studio.js
@@ -89,6 +89,12 @@ function lmsSend() {
                         const out = document.getElementById("txtOutput");
                         await renderEvaResponse(candidate, out);
 
+                        // Keep the global last-response synced so Auto Speak
+                        // and other consumers do not pick up a stale prior turn.
+                        if (typeof lastResponse !== 'undefined') {
+                          lastResponse = candidate;
+                        }
+
                         // Update conversation history
                         openLLMessages.push({ role: "user", content: sQuestion });
                         openLLMessages.push({ role: "assistant", content: candidate });

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -123,8 +123,38 @@ function populateAuthFields() {
   }
 }
 
-function applyStandaloneSurface() {
+function applyStandaloneSimplifications() {
   if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
+
+  var selModel = document.getElementById('selModel');
+  if (selModel) {
+    var modelChanged = selModel.value !== 'aig';
+    Array.from(selModel.children).forEach(function(child) {
+      if (child.tagName === 'OPTGROUP') {
+        var hasAigOption = false;
+        Array.from(child.children).forEach(function(option) {
+          if (option.value === 'aig') {
+            hasAigOption = true;
+          } else {
+            option.remove();
+          }
+        });
+        if (!hasAigOption) child.remove();
+      } else if (child.tagName === 'OPTION' && child.value !== 'aig') {
+        child.remove();
+      }
+    });
+
+    selModel.value = 'aig';
+    var modelLabel = document.querySelector('label[for="selModel"]');
+    if (modelLabel) modelLabel.style.display = 'none';
+    selModel.style.display = 'none';
+
+    if (modelChanged) {
+      selModel.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
   var barkOption = document.querySelector('#selEngine option[value="bark"]');
   if (!barkOption) return;
   var engineSelect = barkOption.parentElement;
@@ -132,6 +162,10 @@ function applyStandaloneSurface() {
     engineSelect.value = 'standard';
   }
   barkOption.remove();
+}
+
+function applyStandaloneSurface() {
+  applyStandaloneSimplifications();
 }
 
 function toggleAuthVis(btn) {
@@ -342,6 +376,7 @@ function updateModelOptionsForTheme(theme) {
       }
     }
   }
+  applyStandaloneSimplifications();
 }
 
 // Settings Menu Options 
@@ -789,6 +824,7 @@ function _detectGenerationIntent() {
 }
 
 function updateButton() {
+  applyStandaloneSimplifications();
     var selModel = document.getElementById("selModel");
     var btnSend = document.getElementById("btnSend");
 
@@ -841,6 +877,7 @@ function updateButton() {
 function sendData() {
     // Hide Eva welcome MOTD on first send
     hideEvaWelcome();
+  applyStandaloneSimplifications();
 
     // Logic required for initial message
     var selModel = document.getElementById("selModel");

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -91,7 +91,9 @@ function saveAuthKeys() {
   });
   // Save ACP Bridge URL separately
   var acpEl = document.getElementById('txtACPBridgeUrl');
-  if (acpEl && acpEl.value.trim()) {
+  if (acpEl && typeof isEvaStandalone === 'function' && isEvaStandalone()) {
+    localStorage.removeItem('acp_bridge_url');
+  } else if (acpEl && acpEl.value.trim()) {
     localStorage.setItem('acp_bridge_url', acpEl.value.trim());
   } else if (acpEl) {
     localStorage.removeItem('acp_bridge_url');
@@ -117,8 +119,19 @@ function populateAuthFields() {
   // Populate ACP Bridge URL
   var acpEl = document.getElementById('txtACPBridgeUrl');
   if (acpEl) {
-    acpEl.value = localStorage.getItem('acp_bridge_url') || 'http://localhost:8888';
+    acpEl.value = (typeof getACPBridgeUrl === 'function') ? getACPBridgeUrl() : (localStorage.getItem('acp_bridge_url') || 'http://localhost:8888');
   }
+}
+
+function applyStandaloneSurface() {
+  if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
+  var barkOption = document.querySelector('#selEngine option[value="bark"]');
+  if (!barkOption) return;
+  var engineSelect = barkOption.parentElement;
+  if (engineSelect && engineSelect.value === 'bark') {
+    engineSelect.value = 'standard';
+  }
+  barkOption.remove();
 }
 
 function toggleAuthVis(btn) {
@@ -348,6 +361,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const lcarsChipTop = document.getElementById('lcarsChipTop');
   const monitorTabs = document.getElementById('lcarsMonitorTabs');
   const monitorPanels = document.getElementById('lcarsMonitorPanels');
+
+  applyStandaloneSurface();
 
   function toggleSettings(event) {
     event.stopPropagation();

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -168,6 +168,149 @@ function applyStandaloneSurface() {
   applyStandaloneSimplifications();
 }
 
+function getSavedMCPConfig() {
+  try {
+    return JSON.parse(localStorage.getItem('mcp_config') || '{}') || {};
+  } catch (error) {
+    return {};
+  }
+}
+
+function hasSavedStandaloneKustoConfig() {
+  var config = getSavedMCPConfig();
+  var kusto = config['kusto-mcp-server'];
+  var env = kusto && kusto.env ? kusto.env : {};
+  return !!(env.KUSTO_CLUSTER_URL && String(env.KUSTO_CLUSTER_URL).trim());
+}
+
+function setStandaloneFirstRunStatus(text) {
+  var status = document.getElementById('firstRunStatus');
+  if (status) status.textContent = text || '';
+}
+
+function updateStandaloneFirstRunSaveState() {
+  var cluster = document.getElementById('firstRunKustoCluster');
+  var database = document.getElementById('firstRunKustoDatabase');
+  var saveButton = document.getElementById('firstRunSave');
+  if (!saveButton) return;
+  saveButton.disabled = !(
+    cluster && cluster.value.trim() &&
+    database && database.value.trim()
+  );
+}
+
+function showStandaloneFirstRunModal() {
+  if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
+  var modal = document.getElementById('firstRunModal');
+  if (!modal) return;
+  var overlay = document.getElementById('settingsOverlay');
+  var cluster = document.getElementById('firstRunKustoCluster');
+  var database = document.getElementById('firstRunKustoDatabase');
+  if (cluster) cluster.value = '';
+  if (database) database.value = '';
+  setStandaloneFirstRunStatus('');
+  if (overlay) overlay.classList.add('open');
+  modal.style.display = 'flex';
+  updateStandaloneFirstRunSaveState();
+  setTimeout(function() {
+    if (cluster) cluster.focus();
+  }, 0);
+}
+
+function hideStandaloneFirstRunModal() {
+  var modal = document.getElementById('firstRunModal');
+  if (modal) modal.style.display = 'none';
+  var settingsMenu = document.getElementById('settingsMenu');
+  var overlay = document.getElementById('settingsOverlay');
+  if (overlay && !(settingsMenu && settingsMenu.classList.contains('open'))) {
+    overlay.classList.remove('open');
+  }
+}
+
+function skipStandaloneFirstRun() {
+  localStorage.setItem('eva_standalone_first_run_done', '1');
+  hideStandaloneFirstRunModal();
+}
+
+async function saveStandaloneFirstRunConfig() {
+  if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
+  var cluster = document.getElementById('firstRunKustoCluster');
+  var database = document.getElementById('firstRunKustoDatabase');
+  var clusterUrl = cluster ? cluster.value.trim() : '';
+  var databaseName = database ? database.value.trim() : '';
+  if (!clusterUrl || !databaseName) return;
+
+  var config = getSavedMCPConfig();
+  config['kusto-mcp-server'] = {
+    command: 'python3',
+    args: ['tools/kusto_mcp.py'],
+    env: {
+      KUSTO_CLUSTER_URL: clusterUrl,
+      KUSTO_DATABASE: databaseName,
+      KUSTO_DATABASE_LOCKED: '1'
+    }
+  };
+  localStorage.setItem('mcp_config', JSON.stringify(config));
+  localStorage.setItem('eva_standalone_first_run_done', '1');
+
+  var kustoCheck = document.getElementById('mcpKusto');
+  var kustoConfig = document.getElementById('mcpKustoConfig');
+  var clusterField = document.getElementById('mcpKustoCluster');
+  var databaseField = document.getElementById('mcpKustoDatabase');
+  if (kustoCheck) kustoCheck.checked = true;
+  if (kustoConfig) kustoConfig.style.display = 'block';
+  if (clusterField) clusterField.value = clusterUrl;
+  if (databaseField) databaseField.value = databaseName;
+  if (typeof updateKustoSeedButtonState === 'function') updateKustoSeedButtonState();
+
+  setStandaloneFirstRunStatus('Configuring Kusto MCP...');
+  var result = { ok: false };
+  if (typeof applyMCPConfig === 'function') {
+    result = await applyMCPConfig();
+  }
+  hideStandaloneFirstRunModal();
+
+  if (result && result.ok) {
+    var shouldSeed = confirm('Seed Eva schema into ' + databaseName + '?');
+    if (shouldSeed && typeof seedEvaSchema === 'function') {
+      await seedEvaSchema(clusterUrl, databaseName, true);
+    }
+  }
+}
+
+function initStandaloneFirstRun() {
+  if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
+  var rerunButton = document.getElementById('standaloneFirstRunButton');
+  if (rerunButton) {
+    rerunButton.style.display = 'block';
+    rerunButton.addEventListener('click', function() {
+      localStorage.removeItem('eva_standalone_first_run_done');
+      showStandaloneFirstRunModal();
+    });
+  }
+
+  var cluster = document.getElementById('firstRunKustoCluster');
+  var database = document.getElementById('firstRunKustoDatabase');
+  var saveButton = document.getElementById('firstRunSave');
+  var skipButton = document.getElementById('firstRunSkip');
+  if (cluster) cluster.addEventListener('input', updateStandaloneFirstRunSaveState);
+  if (database) database.addEventListener('input', updateStandaloneFirstRunSaveState);
+  if (saveButton) saveButton.addEventListener('click', saveStandaloneFirstRunConfig);
+  if (skipButton) {
+    skipButton.addEventListener('click', skipStandaloneFirstRun);
+  }
+  document.addEventListener('keydown', function(event) {
+    var modal = document.getElementById('firstRunModal');
+    if (event.key === 'Escape' && modal && modal.style.display !== 'none') {
+      skipStandaloneFirstRun();
+    }
+  });
+
+  if (!hasSavedStandaloneKustoConfig() && localStorage.getItem('eva_standalone_first_run_done') !== '1') {
+    showStandaloneFirstRunModal();
+  }
+}
+
 function toggleAuthVis(btn) {
   var input = btn.parentElement.querySelector('input');
   if (input.type === 'password') {
@@ -398,6 +541,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const monitorPanels = document.getElementById('lcarsMonitorPanels');
 
   applyStandaloneSurface();
+  initStandaloneFirstRun();
 
   function toggleSettings(event) {
     event.stopPropagation();

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -98,6 +98,18 @@ function saveAuthKeys() {
   } else if (acpEl) {
     localStorage.removeItem('acp_bridge_url');
   }
+  var lmsBaseEl = document.getElementById('aigLmStudioBaseUrl');
+  if (lmsBaseEl && lmsBaseEl.value.trim()) {
+    localStorage.setItem('aig_lmstudio_base_url', lmsBaseEl.value.trim());
+  } else if (lmsBaseEl) {
+    localStorage.removeItem('aig_lmstudio_base_url');
+  }
+  var lmsModelEl = document.getElementById('aigLmStudioModel');
+  if (lmsModelEl && lmsModelEl.value.trim()) {
+    localStorage.setItem('aig_lmstudio_model', lmsModelEl.value.trim());
+  } else if (lmsModelEl) {
+    localStorage.removeItem('aig_lmstudio_model');
+  }
   setStatus('info', 'API keys saved to browser storage.');
 }
 
@@ -121,6 +133,24 @@ function populateAuthFields() {
   if (acpEl) {
     acpEl.value = (typeof getACPBridgeUrl === 'function') ? getACPBridgeUrl() : (localStorage.getItem('acp_bridge_url') || 'http://localhost:8888');
   }
+  var lmsBaseEl = document.getElementById('aigLmStudioBaseUrl');
+  if (lmsBaseEl) {
+    lmsBaseEl.value = (typeof getLmStudioBaseUrl === 'function') ? getLmStudioBaseUrl() : (localStorage.getItem('aig_lmstudio_base_url') || 'http://localhost:1234/v1');
+  }
+  var lmsModelEl = document.getElementById('aigLmStudioModel');
+  if (lmsModelEl) {
+    lmsModelEl.value = (typeof getLmStudioModel === 'function') ? getLmStudioModel() : (localStorage.getItem('aig_lmstudio_model') || 'granite-3.1-8b-instruct');
+  }
+}
+
+function getLmStudioBaseUrl() {
+  var v = (localStorage.getItem('aig_lmstudio_base_url') || '').trim();
+  return v || 'http://localhost:1234/v1';
+}
+
+function getLmStudioModel() {
+  var v = (localStorage.getItem('aig_lmstudio_model') || '').trim();
+  return v || 'granite-3.1-8b-instruct';
 }
 
 function applyStandaloneSimplifications() {
@@ -738,6 +768,11 @@ document.addEventListener('DOMContentLoaded', () => {
       settingsOverlayEl.classList.remove('open');
     });
   }
+
+  ['aigLmStudioBaseUrl', 'aigLmStudioModel'].forEach(function(id) {
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('change', saveAuthKeys);
+  });
 
   // Init auth, system prompt, and model settings
   loadAuthOverrides();
@@ -2480,6 +2515,7 @@ function clearMessages() {
       var key = localStorage.key(i);
       if (key && (key.indexOf('auth_') === 0 || key === 'theme' || key === 'systemPrompt'
           || key === 'lcars_collapsed' || key === 'acp_bridge_url'
+          || key === 'aig_lmstudio_base_url' || key === 'aig_lmstudio_model'
           || key === 'eva_sessions' || key.indexOf('session_') === 0)) {
         keysToKeep.push({ k: key, v: localStorage.getItem(key) });
       }

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -153,6 +153,20 @@ function getLmStudioModel() {
   return v || 'granite-3.1-8b-instruct';
 }
 
+function getSafeBridgeBaseUrl() {
+  var fallback = 'http://localhost:8888';
+  var raw = (typeof getACPBridgeUrl === 'function') ? getACPBridgeUrl() : fallback;
+  try {
+    var parsed = new URL(raw || fallback);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return fallback;
+    }
+    return (parsed.origin + parsed.pathname).replace(/\/+$/, '');
+  } catch (e) {
+    return fallback;
+  }
+}
+
 function applyStandaloneSimplifications() {
   if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
 
@@ -1782,14 +1796,18 @@ function sanitizeForSpeech(input) {
   if (input == null) return '';
   var t = String(input);
   // Remove only well-formed HTML tags. Stray `<` characters are preserved.
-  t = t.replace(/<\/?[a-zA-Z][^>]*>/g, '');
+  var prev;
+  do {
+    prev = t;
+    t = t.replace(/<\/?[a-zA-Z][^>]*>/g, '');
+  } while (t !== prev);
   // Decode the handful of HTML entities that show up in rendered chat content.
   t = t.replace(/&nbsp;/g, ' ')
-       .replace(/&amp;/g, '&')
        .replace(/&lt;/g, '<')
        .replace(/&gt;/g, '>')
        .replace(/&quot;/g, '"')
-       .replace(/&#39;/g, "'");
+       .replace(/&#39;/g, "'")
+       .replace(/&amp;/g, '&');
   // Strip fenced code blocks (TTS reading source code is rarely useful).
   t = t.replace(/```[\s\S]*?```/g, ' ');
   // Drop inline code backticks while keeping the inner text.
@@ -2201,8 +2219,7 @@ async function renderEvaResponse(content, txtOutput) {
 
   function appendArtifactLinks() {
     if (!artifactNames.length) return;
-    var bridgeUrl = (typeof getACPBridgeUrl === 'function') ? getACPBridgeUrl() : 'http://localhost:8888';
-    bridgeUrl = bridgeUrl.replace(/\/+$/, '');
+    var bridgeUrl = getSafeBridgeBaseUrl();
     var bubbles = txtOutput.querySelectorAll('.chat-bubble.eva-bubble');
     var bubble = bubbles.length ? bubbles[bubbles.length - 1] : null;
     if (!bubble) return;

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -189,7 +189,8 @@ function applyStandaloneSimplifications() {
   var barkOption = document.querySelector('#selEngine option[value="bark"]');
   if (engineSelect) {
     var current = engineSelect.value;
-    if (!current || current === 'bark') {
+    var pollyEngine = (current === 'standard' || current === 'neural' || current === 'generative');
+    if (!current || current === 'bark' || pollyEngine) {
       var hasOpenAIKey = (typeof getAuthKey === 'function') ? !!getAuthKey('OPENAI_API_KEY') : !!window.OPENAI_API_KEY;
       engineSelect.value = hasOpenAIKey ? 'openai' : 'browser';
     }

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -2059,8 +2059,21 @@ function renderMarkdown(md) {
   md = md.replace(/^##\s+(.*)$/gm, '<h2>$1<\/h2>');
   md = md.replace(/^#\s+(.*)$/gm, '<h1>$1<\/h1>');
 
+  const linkTokens = [];
+  function stashLink(html) {
+    linkTokens.push(html);
+    return `\u0000LINK${linkTokens.length - 1}\u0000`;
+  }
+
   // Links [text](url)
-  md = md.replace(/\[(.+?)\]\((https?:[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1<\/a>');
+  md = md.replace(/\[(.+?)\]\((https?:\/\/[^\s)]+)\)/g, (m, text, url) => {
+    return stashLink(`<a href="${url}" target="_blank" rel="noopener noreferrer">${text}<\/a>`);
+  });
+
+  // Bare URLs
+  md = md.replace(/(^|[\s(])(https?:\/\/[^\s)<]+)/g, (m, prefix, url) => {
+    return prefix + stashLink(`<a href="${url}" target="_blank" rel="noopener noreferrer">${url}<\/a>`);
+  });
 
   // Bold and italic
   md = md.replace(/\*\*([^\n*][\s\S]*?)\*\*/g, '<strong>$1<\/strong>');
@@ -2086,6 +2099,10 @@ function renderMarkdown(md) {
     const i = Number(idx);
     const lang = langs[i] ? ` class=\"language-${langs[i]}\"` : '';
     return `<pre><code${lang}>${blocks[i]}<\/code><\/pre>`;
+  });
+
+  md = md.replace(/\u0000LINK(\d+)\u0000/g, (m, idx) => {
+    return linkTokens[Number(idx)] || m;
   });
 
   return md;

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -1732,6 +1732,44 @@ function insertImage() {
 }
 
 // AWS Polly
+// Normalize a chunk of model output (raw markdown or rendered HTML) into a
+// clean plain-text string safe to send to a TTS engine. The previous
+// implementation used `/<\/?[^>]+(>|$)/g`, which would swallow everything
+// from a stray `<` to the end of the string. That occasionally truncated the
+// final sentence of a response (for example when the model emitted a `<3` or
+// any other non-tag `<`), so Auto Speak silently dropped trailing content.
+function sanitizeForSpeech(input) {
+  if (input == null) return '';
+  var t = String(input);
+  // Remove only well-formed HTML tags. Stray `<` characters are preserved.
+  t = t.replace(/<\/?[a-zA-Z][^>]*>/g, '');
+  // Decode the handful of HTML entities that show up in rendered chat content.
+  t = t.replace(/&nbsp;/g, ' ')
+       .replace(/&amp;/g, '&')
+       .replace(/&lt;/g, '<')
+       .replace(/&gt;/g, '>')
+       .replace(/&quot;/g, '"')
+       .replace(/&#39;/g, "'");
+  // Strip fenced code blocks (TTS reading source code is rarely useful).
+  t = t.replace(/```[\s\S]*?```/g, ' ');
+  // Drop inline code backticks while keeping the inner text.
+  t = t.replace(/`([^`]+)`/g, '$1');
+  // Markdown emphasis: bold, italic, strikethrough.
+  t = t.replace(/(\*\*|__)(.*?)\1/g, '$2');
+  t = t.replace(/(\*|_)(.*?)\1/g, '$2');
+  t = t.replace(/~~(.*?)~~/g, '$1');
+  // Markdown links: keep the visible text, drop the URL.
+  t = t.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+  t = t.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+  // Headings, blockquotes, and list bullets at line start.
+  t = t.replace(/^[ \t]*#{1,6}[ \t]+/gm, '');
+  t = t.replace(/^[ \t]*>[ \t]?/gm, '');
+  t = t.replace(/^[ \t]*[-*+][ \t]+/gm, '');
+  // Collapse runs of blank lines so the synthesizer does not pause forever.
+  t = t.replace(/\n{3,}/g, '\n\n');
+  return t.trim();
+}
+
 function speakText() {
   var txtOutputEl = document.getElementById('txtOutput');
   var sText = txtOutputEl ? txtOutputEl.innerHTML : '';
@@ -1755,7 +1793,7 @@ function speakText() {
     // cognition-trace markup, which prevents Auto Speak from reading the
     // response twice when the trace details block is rendered after it.
     if (typeof lastResponse === 'string' && lastResponse.trim()) {
-      speechParams.Text = lastResponse.replace(/<\/?[^>]+(>|$)/g, "").trim();
+      speechParams.Text = sanitizeForSpeech(lastResponse);
     } else {
       let text = document.getElementById("txtOutput").innerHTML;
       // Strip any cognition-trace details block first so trace content
@@ -1764,9 +1802,9 @@ function speakText() {
       let textArr = text.split('<span class="eva">Eva:');
       if (textArr.length > 1) {
         let last = textArr[textArr.length - 1];
-        speechParams.Text = last.replace(/<\/?[^>]+(>|$)/g, "").trim();
+        speechParams.Text = sanitizeForSpeech(last);
       } else {
-        speechParams.Text = text;
+        speechParams.Text = sanitizeForSpeech(text);
       }
     }
 

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -1750,28 +1750,24 @@ function speakText() {
         VoiceId: ""
     };
 
-    // Let's speak only the response.
-    let text = document.getElementById("txtOutput").innerHTML;
-
-    // Split the text by "Eva:" to get all of Eva's responses.
-    let textArr = text.split('<span class="eva">Eva:');
-
-    // Check if there are Eva's responses.
-    if (textArr.length > 1) {
-        // Take the last response from Eva.
-        let lastResponse = textArr[textArr.length - 1];
-
-        // Further process to remove any HTML tags and get pure text, if necessary.
-        // This step is crucial to avoid sending HTML tags to the speech API.
-        // Use a regular expression to remove HTML tags.
-        let cleanText = lastResponse.replace(/<\/?[^>]+(>|$)/g, "");
-
-        // Set the cleaned last response to the speechParams.Text.
-        speechParams.Text = cleanText.trim();
+    // Prefer the global `lastResponse` populated by aig.js / copilot.js /
+    // gpt-core.js. That string is the clean final response without any
+    // cognition-trace markup, which prevents Auto Speak from reading the
+    // response twice when the trace details block is rendered after it.
+    if (typeof lastResponse === 'string' && lastResponse.trim()) {
+      speechParams.Text = lastResponse.replace(/<\/?[^>]+(>|$)/g, "").trim();
     } else {
-        // Fallback to the entire text if there's no "Eva:" found.
-        // You might want to handle this case differently.
+      let text = document.getElementById("txtOutput").innerHTML;
+      // Strip any cognition-trace details block first so trace content
+      // (which echoes the implementer/reviewer drafts) does not get spoken.
+      text = text.replace(/<details class="cog-trace"[\s\S]*?<\/details>/g, '');
+      let textArr = text.split('<span class="eva">Eva:');
+      if (textArr.length > 1) {
+        let last = textArr[textArr.length - 1];
+        speechParams.Text = last.replace(/<\/?[^>]+(>|$)/g, "").trim();
+      } else {
         speechParams.Text = text;
+      }
     }
 
     speechParams.VoiceId = document.getElementById("selVoice").value;
@@ -2371,13 +2367,29 @@ document.addEventListener('DOMContentLoaded', function() {
 function shiftBreak() {
 document.querySelector("#txtMsg").addEventListener("keydown", function(event) {
   if (event.shiftKey && event.keyCode === 13) {
-    var newLine = document.createElement("br");
+    // Use the browser's native line-break command so contenteditable
+    // gets the proper trailing-br anchor. The previous manual <br>
+    // insert required two presses to visually break the line because
+    // a single trailing <br> at end-of-text is not rendered.
+    event.preventDefault();
+    try {
+      if (document.execCommand && document.execCommand('insertLineBreak')) {
+        return;
+      }
+    } catch (_) {}
     var sel = window.getSelection();
+    if (!sel || !sel.rangeCount) return;
     var range = sel.getRangeAt(0);
     range.deleteContents();
-    range.insertNode(newLine);
-    range.setStartAfter(newLine);
-    event.preventDefault();
+    var br = document.createElement("br");
+    range.insertNode(br);
+    // Anchor br: ensures the cursor falls on a visibly new line.
+    var anchor = document.createElement("br");
+    range.setStartAfter(br);
+    range.insertNode(anchor);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
   }
 });
 

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -158,12 +158,11 @@ function applyStandaloneSimplifications() {
   var engineSelect = document.getElementById('selEngine');
   var barkOption = document.querySelector('#selEngine option[value="bark"]');
   if (engineSelect) {
-    // Standalone ships without AWS credentials, so default the TTS engine
-    // to the offline browser path. Users can still pick a Polly engine
-    // and provide credentials if they want cloud voices.
     var current = engineSelect.value;
-    if (!current || current === 'bark' || current === 'standard' || current === 'neural' || current === 'generative') {
-      engineSelect.value = 'browser';
+    var pollyEngine = (current === 'standard' || current === 'neural' || current === 'generative');
+    if (!current || current === 'bark' || pollyEngine) {
+      var hasOpenAIKey = (typeof getAuthKey === 'function') ? !!getAuthKey('OPENAI_API_KEY') : !!window.OPENAI_API_KEY;
+      engineSelect.value = hasOpenAIKey ? 'openai' : 'browser';
     }
   }
   if (barkOption) barkOption.remove();
@@ -1777,6 +1776,64 @@ function speakText() {
 
     speechParams.VoiceId = document.getElementById("selVoice").value;
     speechParams.Engine = document.getElementById("selEngine").value;
+
+
+    // OpenAI TTS: cloud voice, requires OPENAI_API_KEY. Reliable fallback when
+    // the host has no offline speech engine installed.
+    if (speechParams.Engine === "openai") {
+      var openaiKey = (typeof getAuthKey === 'function') ? getAuthKey('OPENAI_API_KEY') : (window.OPENAI_API_KEY || '');
+      if (!openaiKey) {
+        var resultElO = document.getElementById('result');
+        var msgO = 'OpenAI TTS requires an API key. Set it in Settings > Auth.';
+        if (resultElO) resultElO.textContent = msgO; else console.warn(msgO);
+        return;
+      }
+      // Map Polly voice ids to OpenAI voices so the existing voice dropdown
+      // still drives a sensible choice.
+      var openaiVoiceMap = {
+        Salli: 'nova',
+        Ruth: 'shimmer',
+        Seoyeon: 'nova',
+        Mia: 'alloy',
+        Tatyana: 'shimmer'
+      };
+      var oaVoice = openaiVoiceMap[speechParams.VoiceId] || 'nova';
+      fetch('https://api.openai.com/v1/audio/speech', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + openaiKey,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini-tts',
+          voice: oaVoice,
+          input: speechParams.Text,
+          response_format: 'mp3'
+        })
+      }).then(function(resp) {
+        if (!resp.ok) {
+          return resp.text().then(function(t) { throw new Error('OpenAI TTS ' + resp.status + ': ' + t.slice(0, 200)); });
+        }
+        return resp.blob();
+      }).then(function(blob) {
+        var url = URL.createObjectURL(blob);
+        var src = document.getElementById('audioSource');
+        var audio = document.getElementById('audioPlayback');
+        if (src) src.src = url;
+        if (audio) {
+          audio.load();
+          audio.setAttribute('autoplay', 'true');
+          try { audio.play(); } catch (_) {}
+        }
+        var resultEl2 = document.getElementById('result');
+        if (resultEl2) resultEl2.textContent = '';
+      }).catch(function(err) {
+        var resultEl3 = document.getElementById('result');
+        var msg3 = (err && err.message) ? err.message : String(err);
+        if (resultEl3) resultEl3.textContent = msg3; else console.warn('OpenAI TTS error:', msg3);
+      });
+      return;
+    }
 
 
     // Browser SpeechSynthesis: offline, no credentials. Used by standalone.

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -195,6 +195,11 @@ function applyStandaloneSimplifications() {
       engineSelect.value = hasOpenAIKey ? 'openai' : 'browser';
     }
   }
+  var pollyValues = ['standard', 'neural', 'generative'];
+  pollyValues.forEach(function (val) {
+    var opt = document.querySelector('#selEngine option[value="' + val + '"]');
+    if (opt) opt.remove();
+  });
   if (barkOption) barkOption.remove();
 }
 

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -189,8 +189,7 @@ function applyStandaloneSimplifications() {
   var barkOption = document.querySelector('#selEngine option[value="bark"]');
   if (engineSelect) {
     var current = engineSelect.value;
-    var pollyEngine = (current === 'standard' || current === 'neural' || current === 'generative');
-    if (!current || current === 'bark' || pollyEngine) {
+    if (!current || current === 'bark') {
       var hasOpenAIKey = (typeof getAuthKey === 'function') ? !!getAuthKey('OPENAI_API_KEY') : !!window.OPENAI_API_KEY;
       engineSelect.value = hasOpenAIKey ? 'openai' : 'browser';
     }

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -155,13 +155,18 @@ function applyStandaloneSimplifications() {
     }
   }
 
+  var engineSelect = document.getElementById('selEngine');
   var barkOption = document.querySelector('#selEngine option[value="bark"]');
-  if (!barkOption) return;
-  var engineSelect = barkOption.parentElement;
-  if (engineSelect && engineSelect.value === 'bark') {
-    engineSelect.value = 'standard';
+  if (engineSelect) {
+    // Standalone ships without AWS credentials, so default the TTS engine
+    // to the offline browser path. Users can still pick a Polly engine
+    // and provide credentials if they want cloud voices.
+    var current = engineSelect.value;
+    if (!current || current === 'bark' || current === 'standard' || current === 'neural' || current === 'generative') {
+      engineSelect.value = 'browser';
+    }
   }
-  barkOption.remove();
+  if (barkOption) barkOption.remove();
 }
 
 function applyStandaloneSurface() {
@@ -1772,6 +1777,36 @@ function speakText() {
 
     speechParams.VoiceId = document.getElementById("selVoice").value;
     speechParams.Engine = document.getElementById("selEngine").value;
+
+
+    // Browser SpeechSynthesis: offline, no credentials. Used by standalone.
+    if (speechParams.Engine === "browser") {
+      if (typeof window.speechSynthesis === 'undefined' || typeof window.SpeechSynthesisUtterance === 'undefined') {
+        var resultEl = document.getElementById('result');
+        var msg = 'Browser TTS not supported in this runtime.';
+        if (resultEl) resultEl.textContent = msg; else console.warn(msg);
+        return;
+      }
+      try { window.speechSynthesis.cancel(); } catch (_) {}
+      var utter = new SpeechSynthesisUtterance(speechParams.Text);
+      // Map the Polly voice id to a BCP-47 language so the browser picks a sensible voice.
+      var voiceLangMap = {
+        Salli: 'en-US',
+        Ruth: 'en-US',
+        Seoyeon: 'ko-KR',
+        Mia: 'es-MX',
+        Tatyana: 'uk-UA'
+      };
+      utter.lang = voiceLangMap[speechParams.VoiceId] || 'en-US';
+      utter.rate = 1.0;
+      utter.pitch = 1.0;
+      try {
+        window.speechSynthesis.speak(utter);
+      } catch (e) {
+        console.warn('SpeechSynthesis error:', e);
+      }
+      return;
+    }
 
 
     // If selEngine is "bark", call barkTTS function

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -2133,6 +2133,31 @@ async function renderEvaResponse(content, txtOutput) {
   }
 
   var text = content.trim();
+  var artifactNames = [];
+  text = text.replace(/^\s*\[\[EVA_FILE\]\]\s+([A-Za-z0-9._-]{1,128})\s*$/gm, function(fullMatch, filename) {
+    artifactNames.push(filename);
+    return '';
+  });
+  if (artifactNames.length) {
+    text = text.replace(/\n{3,}/g, '\n\n').trim();
+  }
+
+  function appendArtifactLinks() {
+    if (!artifactNames.length) return;
+    var bridgeUrl = (typeof getACPBridgeUrl === 'function') ? getACPBridgeUrl() : 'http://localhost:8888';
+    bridgeUrl = bridgeUrl.replace(/\/+$/, '');
+    var bubbles = txtOutput.querySelectorAll('.chat-bubble.eva-bubble');
+    var bubble = bubbles.length ? bubbles[bubbles.length - 1] : null;
+    if (!bubble) return;
+    artifactNames.forEach(function(filename) {
+      var link = document.createElement('a');
+      link.className = 'eva-artifact-link';
+      link.href = bridgeUrl + '/v1/files/' + encodeURIComponent(filename);
+      link.download = filename;
+      link.textContent = 'Download ' + filename;
+      bubble.appendChild(link);
+    });
+  }
 
   // Detect image placeholders — multiple patterns models use
   var imagePatterns = [
@@ -2252,6 +2277,7 @@ async function renderEvaResponse(content, txtOutput) {
     txtOutput.innerHTML += '<div class="chat-bubble eva-bubble"><span class="eva">Eva:</span> <div class="md">' + html2 + '</div></div>';
   }
 
+  appendArtifactLinks();
   txtOutput.scrollTop = txtOutput.scrollHeight;
 
   // Auto-save session after each response

--- a/core/themes/eva.css
+++ b/core/themes/eva.css
@@ -866,6 +866,18 @@ body.theme-eva #txtOutput {
   scroll-padding-bottom: 56px;
   padding-bottom: 56px;
 }
+/* ── Cognition badge — top-right of chat surface in Eva theme ─
+   The base style pins the badge at bottom: 56px / right: 10px,
+   which collides with the send button. Move it to the top of the
+   chat container so it's visible without overlapping input. */
+body.theme-eva .cog-badge[data-active="true"] {
+  bottom: auto;
+  top: 12px;
+  right: 16px;
+  background: rgba(153, 102, 255, 0.14);
+  color: var(--eva-accent, #c4b5fd);
+  border-color: rgba(153, 102, 255, 0.5);
+}
 /* ── Responsive ─────────────────────────────────────────────── */
 @media (max-width: 599px) {
   body.theme-eva { grid-template-columns: 1fr; padding: 0; }

--- a/index.html
+++ b/index.html
@@ -478,6 +478,8 @@
             <label for="mcpKustoDatabase" style="font-size:12px;margin-top:4px">Default Database:</label>
             <input type="text" id="mcpKustoDatabase" placeholder="(optional)" style="font-size:12px">
             <button type="button" id="mcpSeedButton" class="auth-toggle" style="margin-top:8px;width:100%;text-align:center" disabled>Seed Eva Schema</button>
+            <button type="button" id="mcpPurgeArtifactsButton" class="auth-toggle" style="margin-top:8px;width:100%;text-align:center">Purge Artifacts</button>
+            <div id="mcpPurgeArtifactsStatus" style="margin-top:6px;font-size:12px;color:var(--muted-fg,#888)"></div>
             <div id="mcpSeedStatus" class="mcp-status" aria-live="polite" style="margin-top:8px"></div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -189,7 +189,10 @@
 
         <label for="selEngine">TTS Engine:</label>
         <select id="selEngine" onchange="ChangeLang(this)">
-          <option value="openai">OpenAI</option>
+          <option value="standard">Standard</option>
+          <option value="neural">Neural</option>
+          <option value="generative">Generative</option>
+          <option value="openai" selected>OpenAI</option>
           <option value="browser">Browser (offline)</option>
           <option value="bark">Bark</option>
         </select>

--- a/index.html
+++ b/index.html
@@ -297,7 +297,17 @@
               <optgroup label="Fallback">
                 <option value="acp">ACP Bridge (Copilot CLI default)</option>
               </optgroup>
+              <optgroup label="LM Studio (Local)">
+                <option value="lmstudio">LM Studio (configured model)</option>
+              </optgroup>
             </select>
+          </div>
+          <div class="model-opt" id="opt-lmstudio-config">
+            <label for="aigLmStudioBaseUrl">LM Studio base URL:</label>
+            <input type="text" id="aigLmStudioBaseUrl" placeholder="http://localhost:1234/v1" style="width:100%">
+            <label for="aigLmStudioModel" style="margin-top:6px">LM Studio model name:</label>
+            <input type="text" id="aigLmStudioModel" placeholder="granite-3.1-8b-instruct" style="width:100%">
+            <p class="auth-note" style="margin-top:4px">Used when "LM Studio (configured model)" is selected as Eva or cognition backend. Make sure LM Studio's local server is running with this model loaded.</p>
           </div>
           <div id="opt-acpModel" class="model-opt" style="display:none">
             <label for="selACPModel">ACP Model:</label>

--- a/index.html
+++ b/index.html
@@ -478,8 +478,6 @@
             <label for="mcpKustoDatabase" style="font-size:12px;margin-top:4px">Default Database:</label>
             <input type="text" id="mcpKustoDatabase" placeholder="(optional)" style="font-size:12px">
             <button type="button" id="mcpSeedButton" class="auth-toggle" style="margin-top:8px;width:100%;text-align:center" disabled>Seed Eva Schema</button>
-            <button type="button" id="mcpPurgeArtifactsButton" class="auth-toggle" style="margin-top:8px;width:100%;text-align:center">Purge Artifacts</button>
-            <div id="mcpPurgeArtifactsStatus" style="margin-top:6px;font-size:12px;color:var(--muted-fg,#888)"></div>
             <div id="mcpSeedStatus" class="mcp-status" aria-live="polite" style="margin-top:8px"></div>
           </div>
         </div>
@@ -489,6 +487,13 @@
         <button type="button" class="auth-save" onclick="applyMCPConfig()">Apply MCP Config</button>
         <button type="button" id="standaloneFirstRunButton" class="auth-toggle" style="display:none;margin-top:8px;width:100%;text-align:center">Run first-time setup again</button>
         <button type="button" class="auth-toggle" onclick="refreshMCPStatus()" style="margin-top:8px;width:100%;text-align:center">Refresh Status</button>
+
+        <div class="mcp-preset" style="margin-top:12px">
+          <strong>Generated artifacts</strong>
+          <p class="auth-note" style="margin:4px 0 8px">Files Eva creates during a chat (PDFs, CSVs, etc.) are stored on disk and can be deleted at any time.</p>
+          <button type="button" id="mcpPurgeArtifactsButton" class="auth-toggle" style="width:100%;text-align:center">Purge Artifacts</button>
+          <div id="mcpPurgeArtifactsStatus" style="margin-top:6px;font-size:12px;color:var(--muted-fg,#888)"></div>
+        </div>
       </div>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -475,15 +475,38 @@
             <input type="text" id="mcpKustoCluster" placeholder="https://kvc-xxx.region.kusto.windows.net" style="font-size:12px">
             <label for="mcpKustoDatabase" style="font-size:12px;margin-top:4px">Default Database:</label>
             <input type="text" id="mcpKustoDatabase" placeholder="(optional)" style="font-size:12px">
+            <button type="button" id="mcpSeedButton" class="auth-toggle" style="margin-top:8px;width:100%;text-align:center" disabled>Seed Eva Schema</button>
+            <div id="mcpSeedStatus" class="mcp-status" aria-live="polite" style="margin-top:8px"></div>
           </div>
         </div>
 
         <div id="mcpStatus" class="mcp-status"></div>
 
         <button type="button" class="auth-save" onclick="applyMCPConfig()">Apply MCP Config</button>
+        <button type="button" id="standaloneFirstRunButton" class="auth-toggle" style="display:none;margin-top:8px;width:100%;text-align:center">Run first-time setup again</button>
         <button type="button" class="auth-toggle" onclick="refreshMCPStatus()" style="margin-top:8px;width:100%;text-align:center">Refresh Status</button>
       </div>
 
+    </div>
+  </div>
+
+  <div class="settingsMenu" id="firstRunModal" role="dialog" aria-modal="true" aria-labelledby="firstRunModalTitle" style="display:none;position:fixed;top:50%;left:50%;transform:translate(-50%, -50%);width:500px;max-width:95vw;max-height:85vh;background:#fff;border-radius:12px;box-shadow:0 8px 32px rgba(0,0,0,0.3);z-index:10000;overflow:hidden;flex-direction:column;color:#333;">
+    <div class="settings-header">
+      <h3 id="firstRunModalTitle">Set Up Eva Memory</h3>
+    </div>
+    <div class="settings-body">
+      <p class="auth-note">Choose the Azure Data Explorer database Eva should use for memory.</p>
+      <div class="auth-field">
+        <label for="firstRunKustoCluster">Cluster URL:</label>
+        <input type="text" id="firstRunKustoCluster" placeholder="https://kvc-xxx.region.kusto.windows.net" autocomplete="off">
+      </div>
+      <div class="auth-field">
+        <label for="firstRunKustoDatabase">Database name:</label>
+        <input type="text" id="firstRunKustoDatabase" placeholder="eva-standalone" autocomplete="off">
+      </div>
+      <div id="firstRunStatus" class="mcp-status" aria-live="polite"></div>
+      <button type="button" class="auth-save" id="firstRunSave" disabled>Save and continue</button>
+      <button type="button" class="auth-toggle" id="firstRunSkip" style="margin-top:8px;width:100%;text-align:center">Skip for now</button>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -192,6 +192,7 @@
           <option value="standard">Standard</option>
           <option value="neural">Neural</option>
           <option value="generative">Generative</option>
+          <option value="openai">OpenAI</option>
           <option value="browser">Browser (offline)</option>
           <option value="bark">Bark</option>
         </select>

--- a/index.html
+++ b/index.html
@@ -189,9 +189,6 @@
 
         <label for="selEngine">TTS Engine:</label>
         <select id="selEngine" onchange="ChangeLang(this)">
-          <option value="standard">Standard</option>
-          <option value="neural">Neural</option>
-          <option value="generative">Generative</option>
           <option value="openai">OpenAI</option>
           <option value="browser">Browser (offline)</option>
           <option value="bark">Bark</option>

--- a/index.html
+++ b/index.html
@@ -192,6 +192,7 @@
           <option value="standard">Standard</option>
           <option value="neural">Neural</option>
           <option value="generative">Generative</option>
+          <option value="browser">Browser (offline)</option>
           <option value="bark">Bark</option>
         </select>
 

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -51,4 +51,4 @@ The AppImage is self-contained: it spawns the bundled ACP bridge on a random loc
 - The renderer receives the bridge URL through `window.evaStandalone.acpBaseUrl`.
 - Standalone exposes Eva (AIG) only. All routing, cognition, AIG backend selection, and Settings sub-controls remain available.
 - The Kusto database field is intentionally blank on first run. Configure it in Settings > MCP.
-- Bark is hidden in standalone mode. Browser SpeechSynthesis remains available for offline Auto Speak. Polly engines require AWS credentials and are not configured through the standalone Auth tab.
+- TTS engines: standalone defaults to OpenAI TTS when an OpenAI API key is set in Settings > Auth, otherwise falls back to browser SpeechSynthesis. Polly engines (Standard, Neural, Generative) require AWS credentials and are not configured through the standalone Auth tab. Bark is hidden in standalone mode.

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -51,4 +51,4 @@ The AppImage is self-contained: it spawns the bundled ACP bridge on a random loc
 - The renderer receives the bridge URL through `window.evaStandalone.acpBaseUrl`.
 - Standalone exposes Eva (AIG) only. All routing, cognition, AIG backend selection, and Settings sub-controls remain available.
 - The Kusto database field is intentionally blank on first run. Configure it in Settings > MCP.
-- Bark is hidden in standalone mode. AWS Polly remains in the Auth tab, and browser SpeechSynthesis remains available.
+- Bark is hidden in standalone mode. Browser SpeechSynthesis remains available for offline Auto Speak. Polly engines require AWS credentials and are not configured through the standalone Auth tab.

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -30,5 +30,6 @@ The AppImage build is configured in `package.json` but this scaffold does not in
 
 - Electron starts `tools/acp_bridge.py` with `python3` on `127.0.0.1` using a free dynamic port.
 - The renderer receives the bridge URL through `window.evaStandalone.acpBaseUrl`.
+- Standalone exposes Eva (AIG) only. All routing, cognition, AIG backend selection, and Settings sub-controls remain available.
 - The Kusto database field is intentionally blank on first run. Configure it in Settings > MCP.
 - Bark is hidden in standalone mode. AWS Polly remains in the Auth tab, and browser SpeechSynthesis remains available.

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -21,10 +21,29 @@ npm run start
 
 ```sh
 cd standalone
+npm install
 npm run dist
 ```
 
+Output lands in `standalone/dist/`, named like `Eva Standalone-<version>.AppImage` (the version comes from `package.json`).
+
 The AppImage build is configured in `package.json` but this scaffold does not include generated output or a lockfile.
+
+## Launch The AppImage
+
+```sh
+cd standalone/dist
+chmod +x "Eva Standalone-0.1.0.AppImage"
+"./Eva Standalone-0.1.0.AppImage"
+```
+
+If the host is missing FUSE (common on minimal containers and some distros), launch with extraction instead:
+
+```sh
+"./Eva Standalone-0.1.0.AppImage" --appimage-extract-and-run
+```
+
+The AppImage is self-contained: it spawns the bundled ACP bridge on a random localhost port at startup. The host still needs Copilot CLI authenticated once via `copilot auth login`.
 
 ## Runtime Notes
 

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -1,0 +1,34 @@
+# Eva Standalone
+
+This directory contains the Electron scaffold for the Linux AppImage build. The Electron files stay under `standalone/`; electron-builder copies the parent web UI and bridge into `resources/app` with `extraResources`. In development, `main.js` loads the parent repo directly.
+
+## Prerequisites
+
+- Node.js >= 24
+- Python >= 3.12
+- GitHub Copilot CLI installed on the host
+- Copilot CLI authenticated on the host with `copilot auth login`
+
+## Run In Development
+
+```sh
+cd standalone
+npm install
+npm run start
+```
+
+## Build AppImage
+
+```sh
+cd standalone
+npm run dist
+```
+
+The AppImage build is configured in `package.json` but this scaffold does not include generated output or a lockfile.
+
+## Runtime Notes
+
+- Electron starts `tools/acp_bridge.py` with `python3` on `127.0.0.1` using a free dynamic port.
+- The renderer receives the bridge URL through `window.evaStandalone.acpBaseUrl`.
+- The Kusto database field is intentionally blank on first run. Configure it in Settings > MCP.
+- Bark is hidden in standalone mode. AWS Polly remains in the Auth tab, and browser SpeechSynthesis remains available.

--- a/standalone/main.js
+++ b/standalone/main.js
@@ -222,7 +222,26 @@ function startBridge(port) {
     PYTHONUNBUFFERED: '1'
   });
 
-  const child = spawn('python3', args, {
+  // GUI-launched apps on macOS inherit a stripped PATH that often misses
+  // Homebrew, python.org, and nvm bin directories. Augment PATH so the bridge
+  // can find python3 and copilot. Harmless on Linux.
+  if (process.platform === 'darwin') {
+    const extraPaths = [
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/usr/local/sbin',
+      path.join(process.env.HOME || '', '.local/bin'),
+      path.join(process.env.HOME || '', '.npm-global/bin')
+    ].filter(Boolean);
+    const currentPath = env.PATH || '';
+    const merged = extraPaths.concat(currentPath.split(':')).filter(function (p, i, arr) {
+      return p && arr.indexOf(p) === i;
+    }).join(':');
+    env.PATH = merged;
+  }
+
+  const pythonCmd = process.env.EVA_PYTHON || 'python3';
+  const child = spawn(pythonCmd, args, {
     cwd: appRoot,
     env: env,
     detached: true,

--- a/standalone/main.js
+++ b/standalone/main.js
@@ -22,6 +22,19 @@ function clearBridgeStopTimer() {
   }
 }
 
+function groupSignal(child, signal) {
+  if (!child) return;
+  try {
+    if (child.pid) {
+      process.kill(-child.pid, signal);
+      return;
+    }
+  } catch (_) {}
+  try {
+    child.kill(signal);
+  } catch (_) {}
+}
+
 function createAddressInUseError(port) {
   const err = new Error('ACP bridge could not bind to 127.0.0.1:' + port + ' because the port was already in use. Retrying with a new local port.');
   err.code = 'EADDRINUSE';
@@ -56,7 +69,7 @@ function logFatalError(label, err) {
 function exitAfterFatalError(label, err) {
   logFatalError(label, err);
   try {
-    stopBridge();
+    forceKillBridgeSync();
   } finally {
     process.exit(1);
   }
@@ -178,6 +191,27 @@ function waitForBridge(baseUrl, childProcess, timeoutMs) {
   });
 }
 
+function waitForBridgeExit(childProcess, timeoutMs) {
+  return new Promise(function(resolve) {
+    if (!childProcess || childProcess.exitCode !== null || childProcess.signalCode !== null) {
+      resolve();
+      return;
+    }
+    let settled = false;
+    const timer = setTimeout(done, timeoutMs);
+
+    function done() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      childProcess.off('exit', done);
+      resolve();
+    }
+
+    childProcess.once('exit', done);
+  });
+}
+
 function startBridge(port) {
   const appRoot = getAppRoot();
   const bridgePath = path.join(appRoot, 'tools', 'acp_bridge.py');
@@ -190,11 +224,16 @@ function startBridge(port) {
   const child = spawn('python3', args, {
     cwd: appRoot,
     env: env,
+    detached: true,
     stdio: ['ignore', 'pipe', 'pipe']
   });
   let stderrBuffer = '';
 
   bridgeProcess = child;
+  child.evaAwaitingReady = true;
+  child.evaClearStderrBuffer = function() {
+    stderrBuffer = '';
+  };
 
   child.stdout.on('data', function(chunk) {
     process.stdout.write('[eva-acp] ' + chunk.toString());
@@ -203,7 +242,7 @@ function startBridge(port) {
     const text = chunk.toString();
     process.stderr.write('[eva-acp] ' + text);
     stderrBuffer = (stderrBuffer + text).slice(-1000);
-    if (!child.evaAddressInUseError && ADDRESS_IN_USE_PATTERN.test(stderrBuffer)) {
+    if (child.evaAwaitingReady && !child.evaAddressInUseError && ADDRESS_IN_USE_PATTERN.test(stderrBuffer)) {
       const err = createAddressInUseError(port);
       child.evaAddressInUseError = err;
       child.emit('eva-address-in-use', err);
@@ -235,6 +274,21 @@ function startBridge(port) {
   return child;
 }
 
+function forceKillBridgeSync() {
+  shuttingDown = true;
+  const child = bridgeProcess;
+  if (!child || !child.pid) return;
+
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+    return;
+  } catch (err) {
+    try {
+      child.kill('SIGKILL');
+    } catch (_) {}
+  }
+}
+
 function stopBridge() {
   shuttingDown = true;
   if (stoppingBridge) return;
@@ -243,10 +297,10 @@ function stopBridge() {
   const child = bridgeProcess;
   stoppingBridge = true;
   bridgeStoppingProcess = child;
-  child.kill('SIGTERM');
+  groupSignal(child, 'SIGTERM');
   bridgeStopTimer = setTimeout(function() {
     if (bridgeStoppingProcess === child) {
-      child.kill('SIGKILL');
+      groupSignal(child, 'SIGKILL');
     }
   }, 3000);
 }
@@ -289,12 +343,19 @@ async function boot() {
     try {
       await waitForBridge(acpBaseUrl, child, BRIDGE_READY_TIMEOUT_MS);
       readyBridgeProcess = child;
+      child.evaAwaitingReady = false;
+      if (typeof child.evaClearStderrBuffer === 'function') child.evaClearStderrBuffer();
       createWindow(acpBaseUrl);
       return;
     } catch (err) {
       if (err && err.code === 'EADDRINUSE') {
         if (attempt < BRIDGE_PORT_RETRY_LIMIT) {
           console.error('ACP bridge port ' + port + ' was already in use. Retrying with a new local port.');
+          const priorChild = child;
+          await waitForBridgeExit(priorChild, 1000);
+          if (priorChild.exitCode === null && priorChild.signalCode === null) {
+            groupSignal(priorChild, 'SIGKILL');
+          }
           continue;
         }
         throw createPortRetryError();

--- a/standalone/main.js
+++ b/standalone/main.js
@@ -1,0 +1,335 @@
+const { app, BrowserWindow, dialog } = require('electron');
+const http = require('http');
+const net = require('net');
+const path = require('path');
+const { spawn } = require('child_process');
+
+let bridgeProcess = null;
+let readyBridgeProcess = null;
+let bridgeStopTimer = null;
+let bridgeStoppingProcess = null;
+let shuttingDown = false;
+let stoppingBridge = false;
+
+const BRIDGE_READY_TIMEOUT_MS = 60000;
+const BRIDGE_PORT_RETRY_LIMIT = 2;
+const ADDRESS_IN_USE_PATTERN = /Address already in use|EADDRINUSE/i;
+
+function clearBridgeStopTimer() {
+  if (bridgeStopTimer) {
+    clearTimeout(bridgeStopTimer);
+    bridgeStopTimer = null;
+  }
+}
+
+function createAddressInUseError(port) {
+  const err = new Error('ACP bridge could not bind to 127.0.0.1:' + port + ' because the port was already in use. Retrying with a new local port.');
+  err.code = 'EADDRINUSE';
+  err.port = port;
+  return err;
+}
+
+function createPortRetryError() {
+  const attempts = BRIDGE_PORT_RETRY_LIMIT + 1;
+  return new Error('ACP bridge could not bind to a localhost port after ' + attempts + ' attempts because the selected ports were already in use. Close the process using the port or restart Eva Standalone.');
+}
+
+function formatExitDetails(code, signal) {
+  return 'exit code ' + (code === null ? 'none' : code) + ', signal ' + (signal === null ? 'none' : signal);
+}
+
+function getStartupErrorTitle(err) {
+  return err && err.code === 'ENOENT' ? 'Python 3 is required' : 'Eva Standalone could not start';
+}
+
+function getStartupErrorMessage(err) {
+  if (err && err.code === 'ENOENT') {
+    return 'Eva Standalone needs python3 to start the bundled ACP bridge. Install Python 3.12 or newer and try again.';
+  }
+  return err && err.message ? err.message : String(err);
+}
+
+function logFatalError(label, err) {
+  console.error(label, err && err.stack ? err.stack : err);
+}
+
+function exitAfterFatalError(label, err) {
+  logFatalError(label, err);
+  try {
+    stopBridge();
+  } finally {
+    process.exit(1);
+  }
+}
+
+function getAppRoot() {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, 'app');
+  }
+  return path.resolve(__dirname, '..');
+}
+
+function getFreeLocalPort() {
+  return new Promise(function(resolve, reject) {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', function() {
+      const address = server.address();
+      const port = address && address.port;
+      server.close(function() {
+        if (port) {
+          resolve(port);
+        } else {
+          reject(new Error('Unable to allocate a localhost port.'));
+        }
+      });
+    });
+  });
+}
+
+function requestBridgeHealth(baseUrl) {
+  return new Promise(function(resolve, reject) {
+    const req = http.get(baseUrl.replace(/\/+$/, '') + '/health', function(res) {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', function(chunk) { body += chunk; });
+      res.on('end', function() {
+        if (res.statusCode !== 200) {
+          reject(new Error('Bridge health returned HTTP ' + res.statusCode));
+          return;
+        }
+        try {
+          const data = JSON.parse(body);
+          if (data.status === 'ok') {
+            resolve(data);
+          } else {
+            reject(new Error('Bridge health status is ' + data.status));
+          }
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+    req.setTimeout(2000, function() {
+      req.destroy(new Error('Bridge health timed out.'));
+    });
+    req.on('error', reject);
+  });
+}
+
+function waitForBridge(baseUrl, childProcess, timeoutMs) {
+  const startedAt = Date.now();
+  return new Promise(function(resolve, reject) {
+    let settled = false;
+
+    function finish(fn, value) {
+      if (settled) return;
+      settled = true;
+      childProcess.off('exit', onExit);
+      childProcess.off('error', onError);
+      childProcess.off('eva-address-in-use', onAddressInUse);
+      fn(value);
+    }
+
+    function onAddressInUse(err) {
+      finish(reject, err);
+    }
+
+    function onError(err) {
+      childProcess.evaSpawnError = err;
+      finish(reject, err);
+    }
+
+    function onExit(code, signal) {
+      if (childProcess.evaAddressInUseError) {
+        finish(reject, childProcess.evaAddressInUseError);
+        return;
+      }
+      finish(reject, new Error('ACP bridge exited before it was ready (' + formatExitDetails(code, signal) + ').'));
+    }
+
+    function poll() {
+      if (settled) return;
+      requestBridgeHealth(baseUrl).then(function(data) {
+        finish(resolve, data);
+      }).catch(function(err) {
+        if (settled) return;
+        if (Date.now() - startedAt >= timeoutMs) {
+          finish(reject, new Error('Timed out waiting for ACP bridge: ' + err.message));
+          return;
+        }
+        setTimeout(poll, 500);
+      });
+    }
+
+    childProcess.on('exit', onExit);
+    childProcess.on('error', onError);
+    childProcess.on('eva-address-in-use', onAddressInUse);
+    if (childProcess.evaSpawnError) {
+      finish(reject, childProcess.evaSpawnError);
+      return;
+    }
+    if (childProcess.evaAddressInUseError) {
+      finish(reject, childProcess.evaAddressInUseError);
+      return;
+    }
+    poll();
+  });
+}
+
+function startBridge(port) {
+  const appRoot = getAppRoot();
+  const bridgePath = path.join(appRoot, 'tools', 'acp_bridge.py');
+  const args = [bridgePath, '--bind', '127.0.0.1', '--port', String(port), '--cwd', appRoot];
+  const env = Object.assign({}, process.env, {
+    EVA_ACP_PORT: String(port),
+    PYTHONUNBUFFERED: '1'
+  });
+
+  const child = spawn('python3', args, {
+    cwd: appRoot,
+    env: env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  let stderrBuffer = '';
+
+  bridgeProcess = child;
+
+  child.stdout.on('data', function(chunk) {
+    process.stdout.write('[eva-acp] ' + chunk.toString());
+  });
+  child.stderr.on('data', function(chunk) {
+    const text = chunk.toString();
+    process.stderr.write('[eva-acp] ' + text);
+    stderrBuffer = (stderrBuffer + text).slice(-1000);
+    if (!child.evaAddressInUseError && ADDRESS_IN_USE_PATTERN.test(stderrBuffer)) {
+      const err = createAddressInUseError(port);
+      child.evaAddressInUseError = err;
+      child.emit('eva-address-in-use', err);
+      child.kill('SIGTERM');
+    }
+  });
+  child.on('error', function(err) {
+    child.evaSpawnError = err;
+  });
+  child.on('exit', function(code, signal) {
+    const wasReady = readyBridgeProcess === child;
+    if (bridgeProcess === child) {
+      bridgeProcess = null;
+    }
+    if (wasReady) {
+      readyBridgeProcess = null;
+    }
+    if (bridgeStoppingProcess === child) {
+      clearBridgeStopTimer();
+      bridgeStoppingProcess = null;
+      stoppingBridge = false;
+    }
+    if (wasReady && !shuttingDown) {
+      dialog.showErrorBox('ACP bridge stopped', 'The local ACP bridge stopped unexpectedly (' + formatExitDetails(code, signal) + '). Eva Standalone will close so it does not keep running with a broken backend. Restart Eva Standalone to continue.');
+      app.quit();
+    }
+  });
+
+  return child;
+}
+
+function stopBridge() {
+  shuttingDown = true;
+  if (stoppingBridge) return;
+  if (!bridgeProcess) return;
+
+  const child = bridgeProcess;
+  stoppingBridge = true;
+  bridgeStoppingProcess = child;
+  child.kill('SIGTERM');
+  bridgeStopTimer = setTimeout(function() {
+    if (bridgeStoppingProcess === child) {
+      child.kill('SIGKILL');
+    }
+  }, 3000);
+}
+
+function createWindow(acpBaseUrl) {
+  const appRoot = getAppRoot();
+  const mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 900,
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      webSecurity: true,
+      allowRunningInsecureContent: false,
+      additionalArguments: [
+        '--eva-acp-base-url=' + acpBaseUrl,
+        '--eva-version=' + app.getVersion()
+      ]
+    }
+  });
+
+  mainWindow.once('ready-to-show', function() {
+    mainWindow.show();
+  });
+  mainWindow.on('closed', function() {
+    stopBridge();
+  });
+
+  mainWindow.loadFile(path.join(appRoot, 'index.html'));
+}
+
+async function boot() {
+  for (let attempt = 0; attempt <= BRIDGE_PORT_RETRY_LIMIT; attempt += 1) {
+    const port = await getFreeLocalPort();
+    const acpBaseUrl = 'http://127.0.0.1:' + port;
+    const child = startBridge(port);
+    try {
+      await waitForBridge(acpBaseUrl, child, BRIDGE_READY_TIMEOUT_MS);
+      readyBridgeProcess = child;
+      createWindow(acpBaseUrl);
+      return;
+    } catch (err) {
+      if (err && err.code === 'EADDRINUSE') {
+        if (attempt < BRIDGE_PORT_RETRY_LIMIT) {
+          console.error('ACP bridge port ' + port + ' was already in use. Retrying with a new local port.');
+          continue;
+        }
+        throw createPortRetryError();
+      }
+      throw err;
+    }
+  }
+}
+
+app.whenReady().then(function() {
+  boot().catch(function(err) {
+    stopBridge();
+    dialog.showErrorBox(getStartupErrorTitle(err), getStartupErrorMessage(err));
+    app.quit();
+  });
+});
+
+app.on('before-quit', stopBridge);
+app.on('window-all-closed', function() {
+  app.quit();
+});
+
+process.on('SIGINT', function() {
+  stopBridge();
+  app.quit();
+});
+process.on('SIGTERM', function() {
+  stopBridge();
+  app.quit();
+});
+
+process.on('uncaughtException', function(err) {
+  exitAfterFatalError('Uncaught exception in Electron main process:', err);
+});
+
+process.on('unhandledRejection', function(reason) {
+  exitAfterFatalError('Unhandled promise rejection in Electron main process:', reason);
+});

--- a/standalone/main.js
+++ b/standalone/main.js
@@ -218,6 +218,7 @@ function startBridge(port) {
   const args = [bridgePath, '--bind', '127.0.0.1', '--port', String(port), '--cwd', appRoot];
   const env = Object.assign({}, process.env, {
     EVA_ACP_PORT: String(port),
+    KUSTO_DATABASE_LOCKED: '1',
     PYTHONUNBUFFERED: '1'
   });
 

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -1,0 +1,5280 @@
+{
+  "name": "eva-standalone",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eva-standalone",
+      "version": "0.1.0",
+      "devDependencies": {
+        "electron": "^33.0.0",
+        "electron-builder": "^25.0.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
+      "integrity": "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz",
+      "integrity": "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "chalk": "^4.0.0",
+        "debug": "^4.1.1",
+        "detect-libc": "^2.0.1",
+        "fs-extra": "^10.0.0",
+        "got": "^11.7.0",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
+        "node-gyp": "^9.0.0",
+        "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
+        "semver": "^7.3.5",
+        "tar": "^6.0.5",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
+      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.2.7",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/app-builder-bin": {
+      "version": "5.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz",
+      "integrity": "sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz",
+      "integrity": "sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.1",
+        "@electron/rebuild": "3.6.1",
+        "@electron/universal": "2.0.1",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chromium-pickle-js": "^0.2.0",
+        "config-file-ts": "0.2.8-rc1",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "ejs": "^3.1.8",
+        "electron-publish": "25.1.7",
+        "form-data": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "is-ci": "^3.0.0",
+        "isbinaryfile": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.0.0",
+        "resedit": "^1.7.0",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.3.8",
+        "tar": "^6.1.12",
+        "temp-file": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "25.1.8",
+        "electron-builder-squirrel-windows": "25.1.8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.5"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builder-util": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz",
+      "integrity": "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "5.0.0-alpha.10",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "is-ci": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/builder-util/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/builder-util/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts": {
+      "version": "0.2.8-rc1",
+      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
+      "integrity": "sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.3.12",
+        "typescript": "^5.4.3"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dir-compare/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz",
+      "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron": {
+      "version": "33.4.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz",
+      "integrity": "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "dmg-builder": "25.1.8",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz",
+      "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "archiver": "^5.3.1",
+        "builder-util": "25.1.7",
+        "fs-extra": "^10.1.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
+      "integrity": "sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-publish/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-publish/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/temp-file/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/temp-file/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/temp-file/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -6,7 +6,9 @@
   "private": true,
   "scripts": {
     "start": "electron .",
-    "dist": "electron-builder --linux AppImage"
+    "dist": "electron-builder --linux AppImage",
+    "dist:mac": "electron-builder --mac",
+    "dist:all": "electron-builder --linux AppImage --mac"
   },
   "engines": {
     "node": ">=24"
@@ -55,6 +57,19 @@
         "AppImage"
       ],
       "category": "Utility"
+    },
+    "mac": {
+      "target": [
+        {
+          "target": "dmg",
+          "arch": ["x64", "arm64"]
+        },
+        {
+          "target": "zip",
+          "arch": ["x64", "arm64"]
+        }
+      ],
+      "category": "public.app-category.productivity"
     }
   }
 }

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "eva-standalone",
+  "version": "0.1.0",
+  "description": "Localhost Electron shell for Eva AI Assistant.",
+  "main": "main.js",
+  "private": true,
+  "scripts": {
+    "start": "electron .",
+    "dist": "electron-builder --linux AppImage"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "devDependencies": {
+    "electron": "^33.0.0",
+    "electron-builder": "^25.0.0"
+  },
+  "_comment": "Electron files stay in standalone/. electron-builder copies the parent web UI and bridge with extraResources into resources/app.",
+  "build": {
+    "appId": "com.appatalks.eva-standalone",
+    "productName": "Eva Standalone",
+    "files": [
+      "package.json",
+      "main.js",
+      "preload.js"
+    ],
+    "extraResources": [
+      {
+        "from": "..",
+        "to": "app",
+        "filter": [
+          "index.html",
+          "README.md",
+          "README-2.md",
+          "config.example.json",
+          "config.local.example.js",
+          "core/**",
+          "tools/acp_bridge.py",
+          "tools/kusto_mcp.py",
+          "tools/eva_seed.kql",
+          "!config.json",
+          "!config.local.js",
+          "!core/external/*.data",
+          "!audio/**",
+          "!tmp/**",
+          "!*.log",
+          "!**/*.log",
+          "!**/.env*",
+          "!standalone/**"
+        ]
+      }
+    ],
+    "linux": {
+      "target": [
+        "AppImage"
+      ],
+      "category": "Utility"
+    }
+  }
+}

--- a/standalone/preload.js
+++ b/standalone/preload.js
@@ -1,0 +1,15 @@
+const { contextBridge } = require('electron');
+
+function readArg(name) {
+  const prefix = '--' + name + '=';
+  const arg = process.argv.find(function(value) {
+    return value.indexOf(prefix) === 0;
+  });
+  return arg ? arg.slice(prefix.length) : '';
+}
+
+contextBridge.exposeInMainWorld('evaStandalone', Object.freeze({
+  acpBaseUrl: readArg('eva-acp-base-url'),
+  isStandalone: true,
+  version: readArg('eva-version')
+}));

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -29,6 +29,7 @@ The server exposes a single endpoint:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -548,6 +549,7 @@ _session_conversation_buffer = []  # Buffer of recent (user, assistant) pairs fo
 _cognition_launch_iso = None  # UTC timestamp that marks the start of this bridge run
 _cognition_launch_id = None  # Human-readable launch identifier for this bridge run
 _cognition_candidate_counts = {}  # Lowercased entity -> mention count in current launch
+_CONVO_CONTENT_CAP = 8000  # Kusto string columns are unbounded, but cap defensively.
 _kusto_table_columns_cache = {}  # (cluster, db, table) -> [columns]
 _kusto_database_locked = _env_truthy("KUSTO_DATABASE_LOCKED") or _env_truthy("EVA_KUSTO_LOCKED")
 _active_kusto_db = os.environ.get("KUSTO_DATABASE", "").strip()
@@ -936,6 +938,177 @@ _ENTITY_RESERVED_TERMS = {
     "memorysummaries", "selfstate", "heuristicsindex", "emotionbaseline"
 }
 
+_EXPLICIT_FACT_WHITESPACE_RE = re.compile(r"\s+", re.IGNORECASE)
+# CHILDREN, PARTNER, PET, LOCATION patterns deliberately omit re.IGNORECASE
+# so the [A-Z] anchor on the captured name keeps real proper-noun semantics.
+# Users typing "my kids are happy" with a lowercase "happy" are not captured;
+# users typing "my kids are June and Iris" are. That trade is intentional.
+_EXPLICIT_CHILDREN_RE = re.compile(
+    r"\b[Mm]y (?:kid|kids|child|children|son|sons|daughter|daughters)(?:'s| are| is| name(?:s)? (?:are|is))?\s+"
+    r"([A-Z][a-zA-Z]+(?:[\s,]+(?:and\s+)?[A-Z][a-zA-Z]+)*)"
+)
+_EXPLICIT_MOTTO_RE = re.compile(
+    r"\bmy (motto|mantra|creed|philosophy|saying|life motto)(?:\s+is)?[:\s]+[\"“']?([^\"”'\n]{5,200})[\"”']?",
+    re.IGNORECASE
+)
+_EXPLICIT_PARTNER_RE = re.compile(
+    r"\b[Mm]y (wife|husband|partner|spouse|girlfriend|boyfriend)(?:'s name)?(?:\s+is)?\s+([A-Z][a-zA-Z]+)"
+)
+_EXPLICIT_PET_RE = re.compile(
+    r"\b[Mm]y (dog|cat|pet|bird|rabbit|hamster|fish|horse)(?:'s name)?(?:\s+is)?\s+([A-Z][a-zA-Z]+)"
+)
+_EXPLICIT_PREFERENCE_RE = re.compile(
+    r"\bi (?:love|enjoy|prefer|like)\b\s+([a-z][a-zA-Z\s,]{3,80}?)(?:[.!?\n]|$)",
+    re.IGNORECASE
+)
+_EXPLICIT_INTEREST_RE = re.compile(
+    r"\bmy (?:hobby|hobbies|interest|interests|passion|passions) (?:is|are|include|includes)\s+([a-z][a-zA-Z\s,]{3,80}?)(?:[.!?\n]|$)",
+    re.IGNORECASE
+)
+_EXPLICIT_FAVORITE_RE = re.compile(
+    r"\bmy favorite (tv show|tv shows|show|shows|movie|movies|book|books|food|color|game|games|band|song|songs|artist|artists)(?:\s+(?:is|are))?\s+([^.!?\n]{2,120})",
+    re.IGNORECASE
+)
+_EXPLICIT_EMPLOYMENT_RE = re.compile(
+    r"\bi (?:work|am working) (?:as|at|for)\s+([^.!?\n]{2,120})",
+    re.IGNORECASE
+)
+_EXPLICIT_LOCATION_RE = re.compile(
+    r"\b[Ii] (?:live|am based|am located) (?:in|at|near)\s+([A-Z][a-zA-Z\s,]+?)(?:[.!?\n]|$)"
+)
+_EXPLICIT_ROLE_RE = re.compile(
+    r"\bi am (?:a|an)\s+([a-z][a-zA-Z\s]{3,80}?)(?:[.!?\n]|$)",
+    re.IGNORECASE
+)
+# First-token deny-list for the broad ROLE / PREFERENCE patterns. Without this,
+# "I am a bit tired" or "I like that idea" would write trash into the User
+# profile at 0.65 confidence.
+_EXPLICIT_VAGUE_FIRST_TOKENS = {
+    "a", "an", "the", "that", "this", "those", "these", "it",
+    "him", "her", "them", "us", "my", "your", "our", "their",
+    "bit", "lot", "little", "kind", "sort", "type", "couple", "few",
+    "real", "true", "good", "bad", "happy", "sad", "tired", "busy",
+    "quick", "slow", "sure", "fine", "okay", "ok",
+}
+_EXPLICIT_CHILD_SPLIT_RE = re.compile(r"\s*(?:,|\band\b)\s*", re.IGNORECASE)
+_EXPLICIT_FAVORITE_SUFFIXES = {
+    "tv show": "tv_show",
+    "tv shows": "tv_show",
+    "show": "show",
+    "shows": "show",
+    "movie": "movie",
+    "movies": "movie",
+    "book": "book",
+    "books": "book",
+    "food": "food",
+    "color": "color",
+    "game": "game",
+    "games": "game",
+    "band": "band",
+    "song": "song",
+    "songs": "song",
+    "artist": "artist",
+    "artists": "artist",
+}
+
+
+def _clean_explicit_fact_value(raw_value):
+    value = str(raw_value or "").strip().strip("\"“”'")
+    value = _EXPLICIT_FACT_WHITESPACE_RE.sub(" ", value).strip()
+    value = value.rstrip(".,").strip().strip("\"“”'")
+    return value[:200]
+
+
+def _normalize_explicit_children(raw_value):
+    value = _clean_explicit_fact_value(raw_value)
+    children = []
+    for child in _EXPLICIT_CHILD_SPLIT_RE.split(value):
+        child_name = _clean_explicit_fact_value(child)
+        if child_name and child_name.lower() not in _ENTITY_RESERVED_TERMS:
+            children.append(child_name)
+    return ", ".join(children)
+
+
+def _extract_explicit_user_facts(user_message):
+    """Extract direct user-stated facts before generic entity candidates."""
+    import datetime
+    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    facts = []
+    seen = set()
+
+    def add_fact(relation, raw_value, confidence):
+        value = _clean_explicit_fact_value(raw_value)
+        if not value or value.lower() in _ENTITY_RESERVED_TERMS:
+            return
+        key = (relation, value.lower())
+        if key in seen:
+            return
+        seen.add(key)
+        facts.append({
+            "Entity": "User",
+            "Relation": relation,
+            "Value": value,
+            "Confidence": confidence,
+            "Source": "explicit_user_fact",
+            "Timestamp": timestamp,
+            "Decay": 0.005,
+        })
+
+    for match in _EXPLICIT_CHILDREN_RE.finditer(user_message or ""):
+        add_fact("user_children", _normalize_explicit_children(match.group(1)), 0.85)
+    for match in _EXPLICIT_MOTTO_RE.finditer(user_message or ""):
+        add_fact("user_motto", match.group(2), 0.85)
+    for match in _EXPLICIT_PARTNER_RE.finditer(user_message or ""):
+        add_fact("user_partner_name", match.group(2), 0.85)
+    for match in _EXPLICIT_PET_RE.finditer(user_message or ""):
+        species = match.group(1).lower()
+        add_fact(f"user_pet_{species}", match.group(2), 0.85)
+    for match in _EXPLICIT_PREFERENCE_RE.finditer(user_message or ""):
+        captured = match.group(1).strip()
+        first_token = captured.split()[0].lower() if captured else ""
+        if first_token in _EXPLICIT_VAGUE_FIRST_TOKENS:
+            continue
+        add_fact("user_preference", captured, 0.65)
+    for match in _EXPLICIT_INTEREST_RE.finditer(user_message or ""):
+        add_fact("user_interest", match.group(1), 0.7)
+    for match in _EXPLICIT_FAVORITE_RE.finditer(user_message or ""):
+        noun = match.group(1).lower()
+        relation_suffix = _EXPLICIT_FAVORITE_SUFFIXES.get(noun, noun.replace(" ", "_"))
+        add_fact(f"user_favorite_{relation_suffix}", match.group(2), 0.65)
+    for match in _EXPLICIT_EMPLOYMENT_RE.finditer(user_message or ""):
+        add_fact("user_employment", match.group(1), 0.8)
+    for match in _EXPLICIT_LOCATION_RE.finditer(user_message or ""):
+        add_fact("user_location", match.group(1), 0.8)
+    for match in _EXPLICIT_ROLE_RE.finditer(user_message or ""):
+        captured = match.group(1).strip()
+        first_token = captured.split()[0].lower() if captured else ""
+        if first_token in _EXPLICIT_VAGUE_FIRST_TOKENS:
+            continue
+        add_fact("user_role_self_described", captured, 0.65)
+
+    return facts
+
+
+def _explicit_user_fact_covers_candidate(classified_relation, entity, explicit_user_facts):
+    relation_map = {
+        "user_location": {"user_location"},
+        "user_affiliation": {"user_employment"},
+    }
+    matching_relations = relation_map.get(classified_relation)
+    if not matching_relations:
+        return False
+
+    entity_lc = (entity or "").strip().lower()
+    if not entity_lc:
+        return False
+    for fact in explicit_user_facts:
+        if fact.get("Relation") not in matching_relations:
+            continue
+        value_lc = str(fact.get("Value", "")).strip().lower()
+        if value_lc and (entity_lc in value_lc or value_lc in entity_lc):
+            return True
+    return False
+
 
 def _normalize_entity_candidate(raw_entity):
     """Normalize an extracted entity candidate before validation."""
@@ -1067,6 +1240,19 @@ def _build_memory_context(user_message):
 
     context_parts = []
 
+    user_profile_query = (
+        "Knowledge "
+        "| where Entity =~ 'User' and Confidence >= 0.5 "
+        "| summarize arg_max(Timestamp, Value, Confidence) by Relation "
+        "| project Relation, Value, Confidence "
+        "| order by Confidence desc "
+        "| take 30"
+    )
+    user_profile = _kusto_query_direct(cluster, db, user_profile_query)
+    if user_profile:
+        profile_lines = [f"- {item.get('Relation','?')}: {item.get('Value','?')}" for item in user_profile]
+        context_parts.append("[User Profile]\n" + "\n".join(profile_lines))
+
     if _kusto_database_locked:
         db_label = db or "configured database"
         persistent_memory_capability = f"• persistent-memory: Read/write your configured Kusto database ({db_label}). Tables:\n"
@@ -1132,10 +1318,12 @@ def _build_memory_context(user_message):
             context_parts.append(f"[Morning Reflection — {today}]\nNew day. No prior summaries — this is a fresh start.")
 
     # ── 3. Core identity knowledge (always) ────────────────────────────
-    knowledge_empty = True  # Track whether we have any core facts
+    knowledge_empty = not bool(user_profile)  # Track whether we have any core facts
+    # User Profile is injected separately above; this broader block remains secondary context.
     # Fetch ALL high-confidence facts (not scope-limited) so persistent knowledge survives restarts
     core_query = (
         "Knowledge "
+        "| where Entity !~ 'User' "
         "| where Confidence >= 0.6 "
         "and (isnull(Relation) or Relation !in~ ('mentioned', 'candidate_mentioned')) "
         "| order by Confidence desc | take 15"
@@ -1275,16 +1463,40 @@ def _post_response_reflection(user_message, assistant_response, model_name):
     conv_columns = ["SessionId", "Timestamp", "Role", "Provider", "Model", "Content", "TokenEstimate", "ImageGenerated"]
     conv_rows = [
         {"SessionId": session_id, "Timestamp": now, "Role": "user", "Provider": "copilot-acp",
-         "Model": model_name, "Content": user_message[:500], "TokenEstimate": len(user_message.split()),
+         "Model": model_name, "Content": user_message[:_CONVO_CONTENT_CAP], "TokenEstimate": len(user_message.split()),
          "ImageGenerated": False},
         {"SessionId": session_id, "Timestamp": now, "Role": "assistant", "Provider": "copilot-acp",
-         "Model": model_name, "Content": assistant_response[:500], "TokenEstimate": len(assistant_response.split()),
+         "Model": model_name, "Content": assistant_response[:_CONVO_CONTENT_CAP], "TokenEstimate": len(assistant_response.split()),
          "ImageGenerated": False}
     ]
     _kusto_ingest_direct(cluster, db, "Conversations", conv_columns, conv_rows)
     print(f"[Cognition] Logged conversation ({len(user_message)} → {len(assistant_response)} chars)")
 
-    # 2. Extract candidate knowledge with validation/classification
+    # 2. Extract explicit user facts before generic candidate knowledge
+    explicit_user_facts = _extract_explicit_user_facts(user_message)
+    if explicit_user_facts:
+        know_columns = ["Timestamp", "Entity", "Relation", "Value", "Confidence", "Source", "Decay"]
+        rows = []
+        for fact in explicit_user_facts:
+            rows.append({
+                "Timestamp": now,
+                "Entity": fact["Entity"],
+                "Relation": fact["Relation"],
+                "Value": fact["Value"][:200],
+                "Confidence": fact["Confidence"],
+                "Source": source_id,
+                "Decay": 0.005,
+            })
+        if rows and _kusto_ingest_direct(cluster, db, "Knowledge", know_columns, rows):
+            preview = []
+            for row in rows[:5]:
+                preview_value = row["Value"][:40]
+                if len(row["Value"]) > 40:
+                    preview_value += "..."
+                preview.append(f"{row['Relation']}={preview_value}")
+            print(f"[Cognition] Explicit user facts captured: {len(rows)} ({'; '.join(preview)})")
+
+    # 3. Extract candidate knowledge with validation/classification
     import re
     candidate_entities, rejected_entities = _extract_entity_candidates(user_message)
     if rejected_entities:
@@ -1297,6 +1509,8 @@ def _post_response_reflection(user_message, assistant_response, model_name):
         know_rows = []
         for entity in candidate_entities[:3]:
             relation, confidence, value = _classify_entity_candidate(entity, user_message)
+            if _explicit_user_fact_covers_candidate(relation, entity, explicit_user_facts):
+                relation, confidence, value = "candidate_mentioned", 0.2, "candidate extracted from conversation"
             promotion = None
             if relation == "candidate_mentioned":
                 promotion = _maybe_promote_candidate(entity)

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -1709,7 +1709,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
         model_for_response = data.get("model", "gpt-4.1")  # frontend-selectable, default gpt-4.1
 
         # Models available on GitHub Models API (PAT).
-        # Claude/Gemini are NOT available — they must route through ACP.
+        # Models absent from this map must route through ACP.
         # See: https://github.com/marketplace/models/catalog
         # API endpoint: https://models.github.ai/inference/chat/completions
         # Model names use publisher/model format.
@@ -1727,17 +1727,15 @@ class BridgeHandler(BaseHTTPRequestHandler):
             "deepseek-r1": "deepseek/DeepSeek-R1",
             "llama-4-maverick": "meta/llama-4-maverick-17b-128e-instruct-fp8",
         }
-        # Models that MUST go through ACP (not on GitHub Models API)
-        _acp_only_prefixes = ("claude-", "gemini-")
+        # Any selector model not listed in _github_model_map routes
+        # through ACP. This covers Claude, Gemini, and unmapped GPT
+        # variants (e.g. gpt-5.5, gpt-5.3-codex) that Copilot CLI serves.
 
         api_model = _github_model_map.get(model_for_response, model_for_response)
         acp_response_model = ""
         if model_for_response == "acp":
             acp_response_model = ""
-        elif any(model_for_response.startswith(p) for p in _acp_only_prefixes):
-            acp_response_model = model_for_response
         elif model_for_response not in _github_model_map:
-            # Unknown/non-GitHub-Models entries must route through ACP.
             acp_response_model = model_for_response
 
         print(f"[AIG] Model requested: {model_for_response}, API model: {api_model}, PAT present: {bool(github_pat)} ({len(github_pat)} chars)")
@@ -1766,14 +1764,9 @@ class BridgeHandler(BaseHTTPRequestHandler):
             # Explicit ACP routing — skip PAT entirely
             github_pat = ""
 
-        # Claude/Gemini are not on GitHub Models API — must go through ACP
-        if any(model_for_response.startswith(p) for p in _acp_only_prefixes):
+        # Non-mapped models are not on GitHub Models API and must go through ACP.
+        if model_for_response != "acp" and model_for_response not in _github_model_map:
             print(f"[AIG] {model_for_response} not on GitHub Models API, routing to ACP")
-            github_pat = ""
-
-        # OAuth tokens (gho_) only support OpenAI models — route others to ACP
-        elif _using_oauth_token and model_for_response not in _github_model_map:
-            print(f"[AIG] OAuth token can't access {model_for_response}, routing to ACP")
             github_pat = ""
 
         # Inject runtime info so Eva can answer truthfully when asked about her model.

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -500,6 +500,15 @@ def _ensure_kusto_token():
             _kusto_token_cache = token.token
             _kusto_credential = credential
             print(f"[Bridge] Kusto token obtained for direct query calls (length: {len(token.token)})")
+            mcp_config = getattr(acp_client, "mcp_config", {}) if acp_client is not None else {}
+            if (
+                not _cognition_enabled
+                and _kusto_token_cache
+                and acp_client is not None
+                and getattr(acp_client, "alive", False)
+                and "kusto-mcp-server" in mcp_config
+            ):
+                _enable_cognition(mcp_config, model=acp_client.model, port=None)
             return True, ""
         return False, "Kusto token request returned no token"
     except Exception as error:
@@ -2334,6 +2343,16 @@ class BridgeHandler(BaseHTTPRequestHandler):
                 applied += 1
 
         warning = "Re-running this seed will duplicate inline rows."
+        mcp_config = getattr(acp_client, "mcp_config", {}) if acp_client is not None else {}
+        if (
+            not _cognition_enabled
+            and _kusto_token_cache
+            and acp_client is not None
+            and getattr(acp_client, "alive", False)
+            and "kusto-mcp-server" in mcp_config
+        ):
+            bridge_port = getattr(self.server, "server_port", None)
+            _enable_cognition(mcp_config, model=acp_client.model, port=bridge_port)
         self._json_response(200, {
             "ok": failed == 0,
             "applied": applied,

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -2073,6 +2073,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
             "- Do NOT generate fake source citations (AP, Reuters, etc.) unless they appear in [Data Retrieved].\n"
             "- When asked about your base model, underlying model, model ID, or what powers you, "
             "answer using the [Runtime] section below. Do NOT guess or invent a model name.\n"
+            "- When the user asks to show, find, or generate an image, do NOT call the web fetch tool to look up image URLs. Instead emit a placeholder of the form [Image of <short description>] on its own line. The browser resolves the placeholder by calling DALL-E (if the user asked to generate) or Wikimedia (if the user asked to find or show). Do not invent image URLs. Do not say you cannot show or generate images. Up to 3 placeholders per response are supported.\n"
             "- If asked to produce a downloadable file (PDF, CSV, image, etc.), write it to the directory in environment variable EVA_ARTIFACTS_DIR using a short descriptive filename. After the file is written, end your message with a single line containing exactly: [[EVA_FILE]] <filename.ext>. Do not claim a file was produced unless you actually wrote it. Do not include the EVA_FILE marker if no file exists.\n\n"
         )
 

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -571,6 +571,14 @@ def _is_loopback_bind():
     return bind in ("127.0.0.1", "localhost", "::1")
 
 
+def _valid_artifact_name(name):
+    return (
+        bool(re.fullmatch(r"[A-Za-z0-9._-]{1,128}", name or ""))
+        and not name.startswith(".")
+        and not all(char == "." for char in name)
+    )
+
+
 def _get_locked_kusto_database():
     if not _kusto_database_locked:
         return ""
@@ -1762,7 +1770,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
         elif self.path.startswith("/v1/memory/context"):
             self._memory_context()
         elif self.path.startswith("/v1/files/"):
-            requested_name = urllib.parse.unquote(self.path.split("/v1/files/", 1)[1].split("?", 1)[0])
+            requested_name = urllib.parse.unquote(self.path.split("/v1/files/", 1)[1].split("?", 1)[0].split("#", 1)[0])
             self._serve_artifact(requested_name)
         else:
             self.send_error(404, "Not Found")
@@ -1783,19 +1791,12 @@ class BridgeHandler(BaseHTTPRequestHandler):
         else:
             self.send_error(404, "Not Found")
 
-    def _valid_artifact_name(self, name):
-        return (
-            bool(re.fullmatch(r"[A-Za-z0-9._-]{1,128}", name or ""))
-            and not name.startswith(".")
-            and not all(char == "." for char in name)
-        )
-
     def _serve_artifact(self, requested_name):
         if not _is_loopback_bind():
             self._json_response(403, {"error": {"message": "/v1/files is only available on localhost-bound bridges"}})
             return
 
-        if not self._valid_artifact_name(requested_name):
+        if not _valid_artifact_name(requested_name):
             self._json_response(400, {"error": {"message": "invalid filename"}})
             return
 
@@ -1811,7 +1812,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
         self._cors_headers()
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(content_length))
-        self.send_header("Content-Disposition", 'attachment; filename="' + requested_name + '"')
+        # filename is regex-validated; quote defends against future relaxation
+        self.send_header("Content-Disposition", 'attachment; filename="' + urllib.parse.quote(requested_name, safe="") + '"')
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
         with open(target, "rb") as artifact_file:
@@ -1835,13 +1837,17 @@ class BridgeHandler(BaseHTTPRequestHandler):
             os.makedirs(_ARTIFACTS_DIR, exist_ok=True)
             base = os.path.realpath(_ARTIFACTS_DIR)
             for name in os.listdir(_ARTIFACTS_DIR):
-                if not self._valid_artifact_name(name):
+                if not _valid_artifact_name(name):
                     continue
-                target = os.path.realpath(os.path.join(_ARTIFACTS_DIR, name))
+                entry_path = os.path.join(_ARTIFACTS_DIR, name)
+                target = os.path.realpath(entry_path)
                 if not target.startswith(base + os.sep) or not os.path.isfile(target):
                     continue
                 try:
-                    os.remove(target)
+                    if os.path.islink(entry_path):
+                        os.unlink(entry_path)
+                    else:
+                        os.remove(entry_path)
                     purged += 1
                 except FileNotFoundError:
                     pass

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -500,15 +500,6 @@ def _ensure_kusto_token():
             _kusto_token_cache = token.token
             _kusto_credential = credential
             print(f"[Bridge] Kusto token obtained for direct query calls (length: {len(token.token)})")
-            mcp_config = getattr(acp_client, "mcp_config", {}) if acp_client is not None else {}
-            if (
-                not _cognition_enabled
-                and _kusto_token_cache
-                and acp_client is not None
-                and getattr(acp_client, "alive", False)
-                and "kusto-mcp-server" in mcp_config
-            ):
-                _enable_cognition(mcp_config, model=acp_client.model, port=None)
             return True, ""
         return False, "Kusto token request returned no token"
     except Exception as error:
@@ -2345,7 +2336,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
         warning = "Re-running this seed will duplicate inline rows."
         mcp_config = getattr(acp_client, "mcp_config", {}) if acp_client is not None else {}
         if (
-            not _cognition_enabled
+            failed == 0
+            and not _cognition_enabled
             and _kusto_token_cache
             and acp_client is not None
             and getattr(acp_client, "alive", False)

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -842,6 +842,46 @@ def _get_kusto_config():
     return cluster, db
 
 
+def _enable_cognition(mcp_servers, model=None, port=None):
+    """Enable cognition hooks and advertise active bridge capabilities."""
+    global _cognition_enabled, _cognition_launch_iso, _cognition_launch_id, _kusto_table_columns_cache
+    import datetime
+    _kusto_table_columns_cache = {}
+    _cognition_launch_iso = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    _cognition_launch_id = f"eva-{datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d%H%M%S')}"
+    _cognition_enabled = True
+    print(f"[Bridge] Cognition layer ENABLED (memory injection + reflection)")
+    print(f"[Bridge] Cognition launch scope: {_cognition_launch_id} (since {_cognition_launch_iso})")
+
+    cluster, startup_db = _get_kusto_config()
+    if cluster and startup_db:
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+        selfstate_cols = ["Timestamp", "Capability", "Status", "Details"]
+        capabilities = [
+            {"Timestamp": now, "Capability": "kusto_access", "Status": "active",
+             "Details": json.dumps({"cluster": cluster, "database": startup_db})},
+            {"Timestamp": now, "Capability": "acp_bridge", "Status": "active",
+             "Details": json.dumps({"model": model or "default", "port": port})},
+            {"Timestamp": now, "Capability": "cognition", "Status": "active",
+             "Details": json.dumps({"features": ["memory_injection", "reflection", "day_lifecycle", "emotion_tracking"]})},
+            {"Timestamp": now, "Capability": "data_retrieval", "Status": "active",
+             "Details": json.dumps({"skills": ["stock_quotes", "financial_data", "company_info", "web_search"]})},
+            {"Timestamp": now, "Capability": "weather_news", "Status": "active",
+             "Details": json.dumps({"feeds": ["weather", "news", "markets", "space_weather"]})},
+            {"Timestamp": now, "Capability": "image_skills", "Status": "active",
+             "Details": json.dumps({"skills": ["wikimedia_search", "dalle3_generation"]})},
+            {"Timestamp": now, "Capability": "persistent_memory", "Status": "active",
+             "Details": json.dumps({"tables": ["Knowledge", "Conversations", "EmotionState", "MemorySummaries", "Reflections", "SelfState", "HeuristicsIndex", "EmotionBaseline"]})},
+        ]
+        for srv in mcp_servers.keys():
+            capabilities.append({"Timestamp": now, "Capability": f"mcp_{srv}",
+                                 "Status": "active", "Details": "{}"})
+        if _kusto_ingest_direct(cluster, startup_db, "SelfState", selfstate_cols, capabilities):
+            print(f"[Bridge] SelfState written ({len(capabilities)} capabilities)")
+        else:
+            print("[Bridge] SelfState write failed (continuing startup)")
+
+
 def _with_launch_filter(query, timestamp_column="Timestamp"):
     """Scope a Kusto query to rows written during the current cognition launch."""
     if not _cognition_launch_iso:
@@ -2034,7 +2074,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
 
     def _mcp_configure(self):
         """Configure MCP servers and restart the ACP client."""
-        global acp_client
+        global acp_client, _cognition_enabled, _cognition_launch_iso, _cognition_launch_id, _kusto_table_columns_cache
 
         content_length = int(self.headers.get("Content-Length", 0))
         if content_length == 0:
@@ -2089,6 +2129,9 @@ class BridgeHandler(BaseHTTPRequestHandler):
         acp_client = ACPClient(copilot_path=old_path, cwd=old_cwd, model=old_model, mcp_config=mcp_servers)
         try:
             acp_client.start()
+            if "kusto-mcp-server" in mcp_servers and _kusto_token_cache and not _cognition_enabled:
+                bridge_port = getattr(self.server, "server_port", None) or getattr(self.server, "server_address", (None, None))[1]
+                _enable_cognition(mcp_servers, model=old_model, port=bridge_port)
             self._json_response(200, {
                 "status": "ok",
                 "message": f"MCP servers configured: {list(mcp_servers.keys())}",
@@ -2392,41 +2435,7 @@ def main():
     # Enable cognition layer if Kusto MCP is configured
     global _cognition_enabled, _cognition_launch_iso, _cognition_launch_id, _kusto_table_columns_cache
     if "kusto-mcp-server" in mcp_config and _kusto_token_cache:
-        import datetime
-        _kusto_table_columns_cache = {}
-        _cognition_launch_iso = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
-        _cognition_launch_id = f"eva-{datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d%H%M%S')}"
-        _cognition_enabled = True
-        print(f"[Bridge] Cognition layer ENABLED (memory injection + reflection)")
-        print(f"[Bridge] Cognition launch scope: {_cognition_launch_id} (since {_cognition_launch_iso})")
-        # Write SelfState on startup
-        cluster, startup_db = _get_kusto_config()
-        if cluster and startup_db:
-            now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
-            selfstate_cols = ["Timestamp", "Capability", "Status", "Details"]
-            capabilities = [
-                {"Timestamp": now, "Capability": "kusto_access", "Status": "active",
-                 "Details": json.dumps({"cluster": cluster, "database": startup_db})},
-                {"Timestamp": now, "Capability": "acp_bridge", "Status": "active",
-                 "Details": json.dumps({"model": args.model or "default", "port": args.port})},
-                {"Timestamp": now, "Capability": "cognition", "Status": "active",
-                 "Details": json.dumps({"features": ["memory_injection", "reflection", "day_lifecycle", "emotion_tracking"]})},
-                {"Timestamp": now, "Capability": "data_retrieval", "Status": "active",
-                 "Details": json.dumps({"skills": ["stock_quotes", "financial_data", "company_info", "web_search"]})},
-                {"Timestamp": now, "Capability": "weather_news", "Status": "active",
-                 "Details": json.dumps({"feeds": ["weather", "news", "markets", "space_weather"]})},
-                {"Timestamp": now, "Capability": "image_skills", "Status": "active",
-                 "Details": json.dumps({"skills": ["wikimedia_search", "dalle3_generation"]})},
-                {"Timestamp": now, "Capability": "persistent_memory", "Status": "active",
-                 "Details": json.dumps({"tables": ["Knowledge", "Conversations", "EmotionState", "MemorySummaries", "Reflections", "SelfState", "HeuristicsIndex", "EmotionBaseline"]})},
-            ]
-            for srv in mcp_config:
-                capabilities.append({"Timestamp": now, "Capability": f"mcp_{srv}",
-                                     "Status": "active", "Details": "{}"})
-            if _kusto_ingest_direct(cluster, startup_db, "SelfState", selfstate_cols, capabilities):
-                print(f"[Bridge] SelfState written ({len(capabilities)} capabilities)")
-            else:
-                print("[Bridge] SelfState write failed (continuing startup)")
+        _enable_cognition(mcp_config, model=args.model, port=args.port)
     else:
         print(f"[Bridge] Cognition layer disabled (no Kusto MCP or token)")
 

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -549,6 +549,8 @@ _session_conversation_buffer = []  # Buffer of recent (user, assistant) pairs fo
 _cognition_launch_iso = None  # UTC timestamp that marks the start of this bridge run
 _cognition_launch_id = None  # Human-readable launch identifier for this bridge run
 _cognition_candidate_counts = {}  # Lowercased entity -> mention count in current launch
+_candidate_history_cache = {}  # { entity_lower: (timestamp_epoch, mentions, max_confidence) }
+_CANDIDATE_HISTORY_TTL_SECONDS = 60
 _CONVO_CONTENT_CAP = 8000  # Kusto string columns are unbounded, but cap defensively.
 _kusto_table_columns_cache = {}  # (cluster, db, table) -> [columns]
 _kusto_database_locked = _env_truthy("KUSTO_DATABASE_LOCKED") or _env_truthy("EVA_KUSTO_LOCKED")
@@ -1162,26 +1164,79 @@ def _classify_entity_candidate(entity, user_message):
     return "candidate_mentioned", 0.2, "candidate extracted from conversation"
 
 
+def _load_candidate_history(entity):
+    """Load persisted mention history for a candidate entity."""
+    key = (entity or "").strip().lower()
+    if not key:
+        return 0, 0.0
+
+    now = time.time()
+    cached = _candidate_history_cache.get(key)
+    if cached and now - cached[0] < _CANDIDATE_HISTORY_TTL_SECONDS:
+        return cached[1], cached[2]
+
+    cluster, db = _get_kusto_config()
+    if not cluster or not db:
+        return 0, 0.0
+
+    safe_entity = (entity or "").strip().replace("'", "''")
+    query = (
+        "Knowledge\n"
+        f"| where Entity =~ '{safe_entity}'\n"
+        "| summarize Mentions = count(), MaxConfidence = max(Confidence)"
+    )
+    rows = _kusto_query_direct(cluster, db, query)
+    if rows is None:
+        return 0, 0.0
+
+    mentions = 0
+    max_confidence = 0.0
+    if rows:
+        row = rows[0] or {}
+        try:
+            mentions = int(row.get("Mentions") or 0)
+        except (TypeError, ValueError):
+            mentions = 0
+        try:
+            max_confidence = float(row.get("MaxConfidence") or 0.0)
+        except (TypeError, ValueError):
+            max_confidence = 0.0
+
+    _candidate_history_cache[key] = (now, mentions, max_confidence)
+    print(f"[Cognition] Candidate history for \"{entity}\": prior_mentions={mentions} max_conf={max_confidence:.3f}")
+    return mentions, max_confidence
+
+
 def _maybe_promote_candidate(entity):
-    """Promote candidate entities after repeated mentions in the current launch."""
+    """Promote candidate entities after repeated persisted or launch-local mentions."""
     key = (entity or "").strip().lower()
     if not key:
         return None
 
-    seen_count = _cognition_candidate_counts.get(key, 0)
-    if seen_count >= 2:
+    session_count = _cognition_candidate_counts.get(key, 0)
+    prior_mentions, prior_max_conf = _load_candidate_history(entity)
+    total_observations = session_count + prior_mentions
+
+    if prior_max_conf >= 0.6:
         return {
-            "relation": "candidate_confirmed",
+            "relation": "recurring_topic",
+            "confidence": min(0.85, prior_max_conf + 0.05),
+            "value": "reinforced by repeated mention",
+            "reason": "prior_high_confidence"
+        }
+    if total_observations >= 3:
+        return {
+            "relation": "recurring_topic",
             "confidence": 0.75,
             "value": "reinforced by repeated mention",
-            "reason": "reinforced_repetition"
+            "reason": "frequency"
         }
-    if seen_count >= 1:
+    if total_observations >= 2:
         return {
-            "relation": "candidate_confirmed",
+            "relation": "recurring_topic",
             "confidence": 0.65,
             "value": "candidate repeated by user across turns",
-            "reason": "repeated_mention"
+            "reason": "repeat_mention"
         }
     return None
 
@@ -1792,6 +1847,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
 
         messages = data.get("messages", [])
         user_message = data.get("user_message", "")
+        internal = bool(data.get("internal"))
 
         if not user_message and messages:
             for msg in reversed(messages):
@@ -2130,7 +2186,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
                 model_used = "aig:unavailable"
 
         # Step 5: Post-response reflection (background)
-        if response_text and _cognition_enabled:
+        if response_text and _cognition_enabled and not internal:
             threading.Thread(target=_post_response_reflection,
                            args=(user_message, response_text, model_used),
                            daemon=True).start()

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -564,6 +564,8 @@ _kusto_database_locked = _env_truthy("KUSTO_DATABASE_LOCKED") or _env_truthy("EV
 _active_kusto_db = os.environ.get("KUSTO_DATABASE", "").strip()
 _active_kusto_cluster = os.environ.get("KUSTO_CLUSTER_URL", "").strip()
 _bridge_bind_address = "127.0.0.1"
+_LMSTUDIO_ALLOWED_PORTS = {1234, 8000, 8080, 11434}
+_HTTP_CONTENT_TYPE_RE = re.compile(r"^[A-Za-z0-9!#$&^_.+-]+/[A-Za-z0-9!#$&^_.+-]+$")
 
 
 def _is_loopback_bind():
@@ -577,6 +579,50 @@ def _valid_artifact_name(name):
         and not name.startswith(".")
         and not all(char == "." for char in name)
     )
+
+
+def _safe_content_type(value):
+    if value and _HTTP_CONTENT_TYPE_RE.fullmatch(value):
+        return value
+    return "application/octet-stream"
+
+
+def _validate_lmstudio_base_url(raw):
+    value = (raw or "").strip().rstrip("/")
+    if not value:
+        return "", "lmstudio_base_url is required"
+
+    try:
+        parsed = urllib.parse.urlparse(value)
+    except ValueError:
+        return "", "lmstudio_base_url is invalid"
+
+    if parsed.scheme not in ("http", "https"):
+        return "", "lmstudio_base_url must use http or https"
+    if parsed.username or parsed.password:
+        return "", "lmstudio_base_url must not include userinfo"
+    if parsed.query or parsed.fragment:
+        return "", "lmstudio_base_url must not include query or fragment"
+
+    host = (parsed.hostname or "").lower()
+    if host not in ("localhost", "127.0.0.1", "::1"):
+        return "", "lmstudio_base_url must point at localhost"
+
+    try:
+        port = parsed.port
+    except ValueError:
+        return "", "lmstudio_base_url port must be numeric"
+    if port not in _LMSTUDIO_ALLOWED_PORTS:
+        return "", "lmstudio_base_url port is not allowed"
+
+    if parsed.path not in ("", "/v1", "/v1/"):
+        return "", "lmstudio_base_url path must be empty or /v1"
+
+    host_for_url = host
+    if ":" in host_for_url and not host_for_url.startswith("["):
+        host_for_url = "[" + host_for_url + "]"
+    normalized_path = "/v1" if parsed.path in ("/v1", "/v1/") else ""
+    return f"{parsed.scheme}://{host_for_url}:{port}{normalized_path}", ""
 
 
 def _get_locked_kusto_database():
@@ -1806,14 +1852,15 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._json_response(404, {"error": {"message": "file not found"}})
             return
 
-        content_type = mimetypes.guess_type(requested_name)[0] or "application/octet-stream"
+        content_type = _safe_content_type(mimetypes.guess_type(requested_name)[0])
         content_length = os.path.getsize(target)
         self.send_response(200)
         self._cors_headers()
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(content_length))
-        # filename is regex-validated; quote defends against future relaxation
-        self.send_header("Content-Disposition", 'attachment; filename="' + urllib.parse.quote(requested_name, safe="") + '"')
+        # Filename is regex-validated; quote and CRLF stripping defend against future relaxation.
+        quoted_name = urllib.parse.quote(requested_name, safe="").replace("\r", "").replace("\n", "")
+        self.send_header("Content-Disposition", 'attachment; filename="' + quoted_name + '"')
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
         with open(target, "rb") as artifact_file:
@@ -2090,17 +2137,16 @@ class BridgeHandler(BaseHTTPRequestHandler):
             )
 
         if model_for_response == "lmstudio":
-            lms_base = (data.get("lmstudio_base_url") or "").strip().rstrip("/")
+            lms_base = (data.get("lmstudio_base_url") or "").strip()
             lms_model = (data.get("lmstudio_model") or "").strip()
             if not lms_base:
                 lms_base = "http://localhost:1234/v1"
             if not lms_model:
                 lms_model = "granite-3.1-8b-instruct"
 
-            parsed = urllib.parse.urlparse(lms_base)
-            host = (parsed.hostname or "").lower()
-            if host not in ("localhost", "127.0.0.1", "::1"):
-                self._json_response(400, {"error": {"message": "lmstudio_base_url must point at localhost"}})
+            lms_base, lms_error = _validate_lmstudio_base_url(lms_base)
+            if lms_error:
+                self._json_response(400, {"error": {"message": lms_error}})
                 return
 
             eva_system_full = eva_system

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -11,6 +11,7 @@ Requirements:
 Usage:
   python3 tools/acp_bridge.py                    # default port 8888
   python3 tools/acp_bridge.py --port 9999        # custom port
+    EVA_ACP_PORT=9999 python3 tools/acp_bridge.py  # custom port via env
   python3 tools/acp_bridge.py --copilot-path /usr/local/bin/copilot
 
 The server exposes a single endpoint:
@@ -2001,8 +2002,16 @@ class BridgeHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 
 def main():
+    default_port = 8888
+    env_port = os.environ.get("EVA_ACP_PORT", "").strip()
+    if env_port:
+        try:
+            default_port = int(env_port)
+        except ValueError:
+            print(f"[Bridge] Warning: Ignoring invalid EVA_ACP_PORT={env_port!r}")
+
     parser = argparse.ArgumentParser(description="Eva ACP Bridge Server")
-    parser.add_argument("--port", type=int, default=8888, help="HTTP server port (default: 8888)")
+    parser.add_argument("--port", type=int, default=default_port, help="HTTP server port (default: 8888 or EVA_ACP_PORT)")
     parser.add_argument("--bind", default="127.0.0.1", help="Bind address (default: 127.0.0.1, use 0.0.0.0 for LAN access)")
     parser.add_argument("--copilot-path", default="copilot", help="Path to copilot CLI binary")
     parser.add_argument("--cwd", default=os.getcwd(), help="Working directory for ACP session")

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -28,12 +28,14 @@ The server exposes a single endpoint:
 
 import argparse
 import json
+import mimetypes
 import os
 import re
 import subprocess
 import sys
 import threading
 import time
+import urllib.parse
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 # ---------------------------------------------------------------------------
@@ -75,11 +77,13 @@ class ACPClient:
         try:
             # Pass env vars from MCP config to the copilot process itself
             # (copilot spawns MCP servers as children, inheriting the env)
+            os.makedirs(_ARTIFACTS_DIR, exist_ok=True)
             process_env = os.environ.copy()
             for srv_name, srv_cfg in self.mcp_config.items():
                 for k, v in srv_cfg.get('env', {}).items():
                     # subprocess.Popen env requires all values to be strings
                     process_env[k] = str(v) if not isinstance(v, str) else v
+            process_env["EVA_ARTIFACTS_DIR"] = _ARTIFACTS_DIR
 
             self.process = subprocess.Popen(
                 cmd,
@@ -346,6 +350,8 @@ class ACPClient:
         for ev in env_vars:
             if isinstance(ev, dict) and "name" in ev and "value" in ev:
                 env[ev["name"]] = ev["value"]
+        os.makedirs(_ARTIFACTS_DIR, exist_ok=True)
+        env["EVA_ARTIFACTS_DIR"] = _ARTIFACTS_DIR
 
         import uuid
         terminal_id = str(uuid.uuid4())
@@ -552,6 +558,7 @@ _cognition_candidate_counts = {}  # Lowercased entity -> mention count in curren
 _candidate_history_cache = {}  # { entity_lower: (timestamp_epoch, mentions, max_confidence) }
 _CANDIDATE_HISTORY_TTL_SECONDS = 60
 _CONVO_CONTENT_CAP = 8000  # Kusto string columns are unbounded, but cap defensively.
+_ARTIFACTS_DIR = os.path.expanduser("~/.config/eva-standalone/artifacts")
 _kusto_table_columns_cache = {}  # (cluster, db, table) -> [columns]
 _kusto_database_locked = _env_truthy("KUSTO_DATABASE_LOCKED") or _env_truthy("EVA_KUSTO_LOCKED")
 _active_kusto_db = os.environ.get("KUSTO_DATABASE", "").strip()
@@ -850,6 +857,7 @@ def _enable_cognition(mcp_servers, model=None, port=None):
     """Enable cognition hooks and advertise active bridge capabilities."""
     global _cognition_enabled, _cognition_launch_iso, _cognition_launch_id, _kusto_table_columns_cache
     import datetime
+    os.makedirs(_ARTIFACTS_DIR, exist_ok=True)
     _kusto_table_columns_cache = {}
     _cognition_launch_iso = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
     _cognition_launch_id = f"eva-{datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d%H%M%S')}"
@@ -1753,6 +1761,9 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._mcp_status()
         elif self.path.startswith("/v1/memory/context"):
             self._memory_context()
+        elif self.path.startswith("/v1/files/"):
+            requested_name = urllib.parse.unquote(self.path.split("/v1/files/", 1)[1].split("?", 1)[0])
+            self._serve_artifact(requested_name)
         else:
             self.send_error(404, "Not Found")
 
@@ -1767,8 +1778,78 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._aig_chat()
         elif self.path == "/v1/kusto/seed":
             self._kusto_seed()
+        elif self.path == "/v1/files/purge":
+            self._purge_artifacts()
         else:
             self.send_error(404, "Not Found")
+
+    def _valid_artifact_name(self, name):
+        return (
+            bool(re.fullmatch(r"[A-Za-z0-9._-]{1,128}", name or ""))
+            and not name.startswith(".")
+            and not all(char == "." for char in name)
+        )
+
+    def _serve_artifact(self, requested_name):
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "/v1/files is only available on localhost-bound bridges"}})
+            return
+
+        if not self._valid_artifact_name(requested_name):
+            self._json_response(400, {"error": {"message": "invalid filename"}})
+            return
+
+        base = os.path.realpath(_ARTIFACTS_DIR)
+        target = os.path.realpath(os.path.join(_ARTIFACTS_DIR, requested_name))
+        if not target.startswith(base + os.sep) or not os.path.isfile(target):
+            self._json_response(404, {"error": {"message": "file not found"}})
+            return
+
+        content_type = mimetypes.guess_type(requested_name)[0] or "application/octet-stream"
+        content_length = os.path.getsize(target)
+        self.send_response(200)
+        self._cors_headers()
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(content_length))
+        self.send_header("Content-Disposition", 'attachment; filename="' + requested_name + '"')
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        with open(target, "rb") as artifact_file:
+            while True:
+                chunk = artifact_file.read(64 * 1024)
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+
+    def _purge_artifacts(self):
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "/v1/files/purge is only available on localhost-bound bridges"}})
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length:
+            self.rfile.read(content_length)
+
+        purged = 0
+        try:
+            os.makedirs(_ARTIFACTS_DIR, exist_ok=True)
+            base = os.path.realpath(_ARTIFACTS_DIR)
+            for name in os.listdir(_ARTIFACTS_DIR):
+                if not self._valid_artifact_name(name):
+                    continue
+                target = os.path.realpath(os.path.join(_ARTIFACTS_DIR, name))
+                if not target.startswith(base + os.sep) or not os.path.isfile(target):
+                    continue
+                try:
+                    os.remove(target)
+                    purged += 1
+                except FileNotFoundError:
+                    pass
+        except OSError as error:
+            self._json_response(500, {"error": {"message": "artifact purge failed: " + str(error)}})
+            return
+
+        self._json_response(200, {"status": "ok", "purged": purged})
 
     def _health(self):
         status = {
@@ -1981,7 +2062,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             "honestly say you could not retrieve that information right now.\n"
             "- Do NOT generate fake source citations (AP, Reuters, etc.) unless they appear in [Data Retrieved].\n"
             "- When asked about your base model, underlying model, model ID, or what powers you, "
-            "answer using the [Runtime] section below. Do NOT guess or invent a model name.\n\n"
+            "answer using the [Runtime] section below. Do NOT guess or invent a model name.\n"
+            "- If asked to produce a downloadable file (PDF, CSV, image, etc.), write it to the directory in environment variable EVA_ARTIFACTS_DIR using a short descriptive filename. After the file is written, end your message with a single line containing exactly: [[EVA_FILE]] <filename.ext>. Do not claim a file was produced unless you actually wrote it. Do not include the EVA_FILE marker if no file exists.\n\n"
         )
 
         if memory_context:
@@ -2724,12 +2806,14 @@ def main():
     server = HTTPServer((args.bind, args.port), BridgeHandler)
     print(f"[Bridge] Listening on http://{args.bind}:{args.port}")
     print(f"[Bridge] Endpoints:")
-    print(f"  POST /v1/chat/completions   — Send chat messages")
-    print(f"  GET  /v1/models             — List available models")
-    print(f"  GET  /v1/mcp                — MCP server status")
-    print(f"  POST /v1/mcp/configure      — Configure MCP servers (hot-reload)")
+    print(f"  POST /v1/chat/completions   - Send chat messages")
+    print(f"  GET  /v1/models             - List available models")
+    print(f"  GET  /v1/mcp                - MCP server status")
+    print(f"  POST /v1/mcp/configure      - Configure MCP servers (hot-reload)")
     print(f"  POST /v1/kusto/seed         - Apply Eva Kusto schema seed")
-    print(f"  GET  /health                — Health check")
+    print(f"  GET  /v1/files/<name>       - Download a generated artifact")
+    print(f"  POST /v1/files/purge        - Delete all artifacts")
+    print(f"  GET  /health                - Health check")
     print()
 
     try:

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -1935,6 +1935,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
         messages = data.get("messages", [])
         user_message = data.get("user_message", "")
         internal = bool(data.get("internal"))
+        model_for_response = data.get("model", "gpt-4.1")  # frontend-selectable, default gpt-4.1
 
         if not user_message and messages:
             for msg in reversed(messages):
@@ -1963,7 +1964,10 @@ class BridgeHandler(BaseHTTPRequestHandler):
         skip_acp = False
         _acp_route = "default"
 
-        if not (acp_client and acp_client.alive):
+        if model_for_response == "lmstudio":
+            skip_acp = True
+            _acp_route = "lmstudio-no-tools"
+        elif not (acp_client and acp_client.alive):
             skip_acp = True
             _acp_route = "acp-unavailable"
         elif len(msg_words) <= 4 and _re.match(
@@ -2084,6 +2088,68 @@ class BridgeHandler(BaseHTTPRequestHandler):
                 "Answer directly from [Data Retrieved].\n"
             )
 
+        if model_for_response == "lmstudio":
+            lms_base = (data.get("lmstudio_base_url") or "").strip().rstrip("/")
+            lms_model = (data.get("lmstudio_model") or "").strip()
+            if not lms_base:
+                lms_base = "http://localhost:1234/v1"
+            if not lms_model:
+                lms_model = "granite-3.1-8b-instruct"
+
+            parsed = urllib.parse.urlparse(lms_base)
+            host = (parsed.hostname or "").lower()
+            if host not in ("localhost", "127.0.0.1", "::1"):
+                self._json_response(400, {"error": {"message": "lmstudio_base_url must point at localhost"}})
+                return
+
+            eva_system_full = eva_system
+
+            lms_messages = [{"role": "system", "content": eva_system_full}]
+            for msg in messages[-6:]:
+                if msg.get("role") and msg.get("content"):
+                    lms_messages.append({"role": msg["role"], "content": msg["content"]})
+            lms_messages.append({"role": "user", "content": user_message})
+
+            try:
+                import requests as _req
+                lms_resp = _req.post(
+                    lms_base + "/chat/completions",
+                    json={"model": lms_model, "messages": lms_messages, "temperature": 0.7},
+                    timeout=120,
+                )
+                if lms_resp.status_code == 200:
+                    lms_body = lms_resp.json()
+                    response_text = (lms_body.get("choices") or [{}])[0].get("message", {}).get("content", "")
+                    model_used = "aig:lmstudio:" + lms_model
+                else:
+                    response_text = f"LM Studio returned HTTP {lms_resp.status_code}"
+                    model_used = "aig:lmstudio:error"
+            except Exception as _lms_err:
+                response_text = f"LM Studio request failed: {_lms_err}"
+                model_used = "aig:lmstudio:unavailable"
+
+            print(f"[AIG] LM Studio response: {len(response_text)} chars from {lms_model}")
+
+            if response_text and _cognition_enabled and not internal:
+                threading.Thread(target=_post_response_reflection,
+                                 args=(user_message, response_text, model_used),
+                                 daemon=True).start()
+
+            response = {
+                "id": f"aig-{int(time.time())}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model_used,
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": response_text},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+            }
+            self._json_response(200, response)
+            return
+
         # Step 4: Pick the best PAT model for response generation
         # Priority: request body PAT > env var > Copilot CLI OAuth token > ACP fallback
         github_pat = data.get("github_pat", "") or os.environ.get("GITHUB_PAT", "")
@@ -2103,8 +2169,6 @@ class BridgeHandler(BaseHTTPRequestHandler):
                         print("[AIG] Using Copilot CLI OAuth token for GitHub Models API")
             except Exception as _e:
                 print(f"[AIG] Could not read Copilot OAuth: {_e}")
-
-        model_for_response = data.get("model", "gpt-4.1")  # frontend-selectable, default gpt-4.1
 
         # Models available on GitHub Models API (PAT).
         # Models absent from this map must route through ACP.

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -483,6 +483,56 @@ def _inject_kusto_token(mcp_config):
 
     return mcp_config
 
+def _ensure_kusto_token():
+    """Ensure the bridge has a Kusto token for direct bridge-side Kusto calls."""
+    global _kusto_token_cache, _kusto_credential
+    if _kusto_token_cache:
+        return True, ""
+    if _refresh_kusto_token():
+        return True, ""
+    try:
+        from azure.identity import DeviceCodeCredential, TokenCachePersistenceOptions
+        cache_opts = TokenCachePersistenceOptions(allow_unencrypted_storage=True)
+        credential = DeviceCodeCredential(cache_persistence_options=cache_opts)
+        token = credential.get_token("https://kusto.kusto.windows.net/.default")
+        if token and getattr(token, "token", None):
+            _kusto_token_cache = token.token
+            _kusto_credential = credential
+            print(f"[Bridge] Kusto token obtained for direct query calls (length: {len(token.token)})")
+            return True, ""
+        return False, "Kusto token request returned no token"
+    except Exception as error:
+        return False, str(error)
+
+def _split_kusto_seed_blocks(seed_text):
+    """Split seed KQL into executable management command blocks."""
+    import re
+    blocks = []
+    for raw_block in re.split(r"\n\s*\n", seed_text):
+        lines = []
+        for line in raw_block.splitlines():
+            if line.strip().startswith("//"):
+                continue
+            lines.append(line)
+        block = "\n".join(lines).strip()
+        if block:
+            blocks.append(block)
+    return blocks
+
+
+def _env_truthy(name):
+    """Return True when an environment flag uses the shared truthy form."""
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
+def _normalize_kusto_cluster_url(cluster_url):
+    """Normalize a Kusto cluster URL for policy comparisons."""
+    return str(cluster_url or "").strip().rstrip("/").lower()
+
+
+def _same_kusto_cluster(left, right):
+    return _normalize_kusto_cluster_url(left) == _normalize_kusto_cluster_url(right)
+
 
 # ---------------------------------------------------------------------------
 # HTTP Server — exposes the ACP client as an OpenAI-compatible endpoint
@@ -499,6 +549,30 @@ _cognition_launch_iso = None  # UTC timestamp that marks the start of this bridg
 _cognition_launch_id = None  # Human-readable launch identifier for this bridge run
 _cognition_candidate_counts = {}  # Lowercased entity -> mention count in current launch
 _kusto_table_columns_cache = {}  # (cluster, db, table) -> [columns]
+_kusto_database_locked = _env_truthy("KUSTO_DATABASE_LOCKED") or _env_truthy("EVA_KUSTO_LOCKED")
+_active_kusto_db = os.environ.get("KUSTO_DATABASE", "").strip()
+_active_kusto_cluster = os.environ.get("KUSTO_CLUSTER_URL", "").strip()
+_bridge_bind_address = "127.0.0.1"
+
+
+def _is_loopback_bind():
+    bind = (_bridge_bind_address or "").strip().lower()
+    return bind in ("127.0.0.1", "localhost", "::1")
+
+
+def _get_locked_kusto_database():
+    if not _kusto_database_locked:
+        return ""
+    return (_active_kusto_db or os.environ.get("KUSTO_DATABASE", "")).strip()
+
+
+def _capture_active_kusto_env(mcp_config):
+    """Track the Kusto config currently posted to the bridge."""
+    global _active_kusto_db, _active_kusto_cluster
+    kusto_cfg = (mcp_config or {}).get("kusto-mcp-server", {})
+    env = kusto_cfg.get("env", {}) if isinstance(kusto_cfg, dict) else {}
+    _active_kusto_db = str(env.get("KUSTO_DATABASE", "") or os.environ.get("KUSTO_DATABASE", "")).strip()
+    _active_kusto_cluster = str(env.get("KUSTO_CLUSTER_URL", "") or os.environ.get("KUSTO_CLUSTER_URL", "")).strip()
 
 
 class _MSALSilentCredential:
@@ -580,6 +654,62 @@ def _kusto_query_direct(cluster_url, database, query, is_mgmt=False):
         except Exception as e:
             print(f"[Cognition] Kusto query error: {e}")
             return None
+
+
+def _short_kusto_error(value):
+    if isinstance(value, (dict, list)):
+        text = json.dumps(value)
+    else:
+        text = str(value or "")
+    return text[:300]
+
+
+def _kusto_query_with_error(cluster_url, database, query, is_mgmt=False):
+    """Execute a Kusto query and return (rows, error_text) for seed diagnostics."""
+    global _kusto_token_cache
+    if not _kusto_token_cache:
+        return None, "Kusto token is not available"
+    import requests as _requests_mod
+    endpoint = "mgmt" if is_mgmt else "query"
+    url = f"{cluster_url}/v1/rest/{endpoint}"
+    headers = {"Authorization": f"Bearer {_kusto_token_cache}", "Content-Type": "application/json"}
+    payload = {"csl": query, "db": database}
+
+    for attempt in range(3):
+        try:
+            session = _requests_mod.Session()
+            resp = session.post(url, json=payload, headers=headers, timeout=15)
+            session.close()
+            if resp.status_code == 200:
+                try:
+                    data = resp.json()
+                except ValueError as error:
+                    return None, f"Kusto returned invalid JSON: {_short_kusto_error(error)}"
+                exceptions = data.get("Exceptions", [])
+                if exceptions:
+                    return None, _short_kusto_error(exceptions[0])
+                one_api = data.get("OneApiErrors", [])
+                if one_api:
+                    return None, _short_kusto_error(one_api[0])
+                tables = data.get("Tables", [])
+                if tables:
+                    rows = tables[0].get("Rows", [])
+                    cols = [c["ColumnName"] for c in tables[0].get("Columns", [])]
+                    if rows:
+                        return [dict(zip(cols, row)) for row in rows], ""
+                return [], ""
+            if resp.status_code == 401 and attempt == 0 and _refresh_kusto_token():
+                headers["Authorization"] = f"Bearer {_kusto_token_cache}"
+                continue
+            error_text = resp.text[:300] if resp.text else "empty response"
+            return None, f"Kusto API error {resp.status_code}: {error_text}"
+        except (_requests_mod.exceptions.SSLError, _requests_mod.exceptions.ConnectionError) as error:
+            if attempt < 2:
+                time.sleep(1)
+                continue
+            return None, f"Kusto connection error: {_short_kusto_error(error)}"
+        except Exception as error:
+            return None, f"Kusto query error: {_short_kusto_error(error)}"
 
 
 def _get_table_columns(cluster_url, database, table):
@@ -702,9 +832,12 @@ def _get_kusto_config():
         return None, None
     kusto_cfg = acp_client.mcp_config.get("kusto-mcp-server", {})
     env = kusto_cfg.get("env", {})
-    cluster = env.get("KUSTO_CLUSTER_URL", "")
-    db = env.get("KUSTO_DATABASE", "Eva")
-    if not db:
+    cluster = env.get("KUSTO_CLUSTER_URL", "") or _active_kusto_cluster
+    if _kusto_database_locked:
+        db = _get_locked_kusto_database()
+    else:
+        db = env.get("KUSTO_DATABASE", "") or _active_kusto_db
+    if not db and not _kusto_database_locked:
         db = "Eva"
     return cluster, db
 
@@ -889,10 +1022,18 @@ def _build_memory_context(user_message):
         return ""
 
     cluster, db = _get_kusto_config()
-    if not cluster:
+    if not cluster or not db:
         return ""
 
     context_parts = []
+
+    if _kusto_database_locked:
+        db_label = db or "configured database"
+        persistent_memory_capability = f"• persistent-memory: Read/write your configured Kusto database ({db_label}). Tables:\n"
+        kusto_query_capability = f"• kusto-query: Execute KQL queries against the configured Kusto database ({db_label})\n"
+    else:
+        persistent_memory_capability = "• persistent-memory: Read/write your Kusto database (Eva). Tables:\n"
+        kusto_query_capability = "• kusto-query: Execute arbitrary KQL queries against any database (Eva, MEMORY_CORE, ynot)\n"
 
     # ── 1. Skills manifest (always injected, concise) ──────────────────
     import datetime
@@ -907,7 +1048,7 @@ def _build_memory_context(user_message):
         "• weather-news: Real-time weather, news headlines, market summaries, space weather via MCP tools\n"
         "• image-search: Find images on Wikimedia Commons for any topic\n"
         "• image-generation: Generate images via DALL-E 3 (use [Image of <description>] syntax)\n"
-        "• persistent-memory: Read/write your Kusto database (Eva). Tables:\n"
+        f"{persistent_memory_capability}"
         "    Knowledge (Entity, Relation, Value, Confidence) — facts about the user and world\n"
         "    Conversations (SessionId, Role, Content) — chat history\n"
         "    EmotionState (Joy, Curiosity, Concern, Trigger) — your emotional readings\n"
@@ -916,7 +1057,7 @@ def _build_memory_context(user_message):
         "    SelfState (Capability, Status) — your active capabilities\n"
         "    HeuristicsIndex (Entity, Category, Frequency) — pattern tracking\n"
         "    EmotionBaseline (Dimension, Value) — emotional defaults\n"
-        "• kusto-query: Execute arbitrary KQL queries against any database (Eva, MEMORY_CORE, ynot)\n"
+        f"{kusto_query_capability}"
         "• web-search: Search the web and retrieve current information via MCP tools\n"
         "\n"
         "[Workflow: Data Requests]\n"
@@ -1018,18 +1159,17 @@ def _build_memory_context(user_message):
     import re as _re
 
     if _re.search(r'\b(database|databases|kusto|adx|data explorer)\b', msg_lower):
-        dbs = _kusto_query_direct(cluster, "Eva", ".show databases", is_mgmt=True)
-        if dbs:
-            db_names = [d.get('DatabaseName', '?') for d in dbs if 'DatabaseName' in d]
-            if db_names:
-                context_parts.append(f"[Live Data] Databases: {', '.join(db_names)}")
+        if _kusto_database_locked:
+            context_parts.append(f"[Live Data] Database: {db}")
+        else:
+            dbs = _kusto_query_direct(cluster, db, ".show databases", is_mgmt=True)
+            if dbs:
+                db_names = [d.get('DatabaseName', '?') for d in dbs if 'DatabaseName' in d]
+                if db_names:
+                    context_parts.append(f"[Live Data] Databases: {', '.join(db_names)}")
 
     if _re.search(r'\b(tables?|schema|columns?)\b', msg_lower):
         target_db = db
-        for known_db in ['ynot', 'MEMORY_CORE', 'Eva']:
-            if known_db.lower() in msg_lower:
-                target_db = known_db
-                break
         tables = _kusto_query_direct(cluster, target_db, ".show tables", is_mgmt=True)
         if tables:
             tbl_names = [t.get('TableName', '?') for t in tables if 'TableName' in t]
@@ -1083,7 +1223,7 @@ def _post_response_reflection(user_message, assistant_response, model_name):
         return
 
     cluster, db = _get_kusto_config()
-    if not cluster:
+    if not cluster or not db:
         return
 
     import datetime, uuid
@@ -1316,6 +1456,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._memory_reflect()
         elif self.path == "/v1/aig/chat":
             self._aig_chat()
+        elif self.path == "/v1/kusto/seed":
+            self._kusto_seed()
         else:
             self.send_error(404, "Not Found")
 
@@ -1812,6 +1954,91 @@ class BridgeHandler(BaseHTTPRequestHandler):
 
         self._json_response(200, {"status": "ok"})
 
+    def _kusto_seed(self):
+        """Apply the Eva Kusto schema seed file to a configured database."""
+        # Seed runs Kusto management commands, so refuse it on non-loopback binds.
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "/v1/kusto/seed is only available on localhost-bound bridges"}})
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length == 0:
+            self._json_response(400, {"error": {"message": "Empty request body"}})
+            return
+
+        body = self.rfile.read(content_length).decode("utf-8")
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            self._json_response(400, {"error": {"message": "Invalid JSON"}})
+            return
+
+        cluster_url = str(data.get("cluster_url", "")).strip()
+        database = str(data.get("database", "")).strip()
+        if not cluster_url or not database:
+            self._json_response(400, {"error": {"message": "cluster_url and database are required"}})
+            return
+
+        expected_cluster = os.environ.get("KUSTO_CLUSTER_URL", "").strip()
+        if expected_cluster and not _same_kusto_cluster(cluster_url, expected_cluster):
+            self._json_response(400, {"error": {"message": "cluster_url does not match configured KUSTO_CLUSTER_URL"}})
+            return
+
+        if _kusto_database_locked:
+            locked_database = _get_locked_kusto_database()
+            if not locked_database:
+                self._json_response(400, {"error": {"message": "KUSTO_DATABASE is required when KUSTO_DATABASE_LOCKED is set"}})
+                return
+            if database.lower() != locked_database.lower():
+                self._json_response(400, {"error": {"message": "database does not match locked KUSTO_DATABASE"}})
+                return
+            if _active_kusto_cluster and not _same_kusto_cluster(cluster_url, _active_kusto_cluster):
+                self._json_response(400, {"error": {"message": "cluster_url does not match active Kusto MCP configuration"}})
+                return
+            database = locked_database
+
+        token_ok, token_error = _ensure_kusto_token()
+        if not token_ok:
+            self._json_response(503, {
+                "ok": False,
+                "applied": 0,
+                "failed": 1,
+                "errors": ["Kusto authentication failed: " + token_error],
+                "warning": "Re-running this seed will duplicate inline rows."
+            })
+            return
+
+        seed_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "eva_seed.kql")
+        try:
+            with open(seed_path, "r", encoding="utf-8") as seed_file:
+                seed_text = seed_file.read()
+        except OSError as error:
+            self._json_response(500, {"error": {"message": "Could not read eva_seed.kql: " + str(error)}})
+            return
+
+        applied = 0
+        failed = 0
+        errors = []
+        blocks = _split_kusto_seed_blocks(seed_text)
+        # TODO: The inline seed rows use fixed values, so repeated runs can duplicate rows.
+        for index, block in enumerate(blocks, start=1):
+            result, kusto_error = _kusto_query_with_error(cluster_url, database, block, is_mgmt=True)
+            if result is None:
+                failed += 1
+                first_line = block.splitlines()[0] if block.splitlines() else "empty block"
+                errors.append(f"Block {index} failed: {first_line[:120]}: {kusto_error or 'no Kusto diagnostic returned'}")
+            else:
+                applied += 1
+
+        warning = "Re-running this seed will duplicate inline rows."
+        self._json_response(200, {
+            "ok": failed == 0,
+            "applied": applied,
+            "failed": failed,
+            "errors": errors,
+            "warning": warning
+        })
+
     def _mcp_configure(self):
         """Configure MCP servers and restart the ACP client."""
         global acp_client
@@ -1848,8 +2075,16 @@ class BridgeHandler(BaseHTTPRequestHandler):
                 resolved_env[k] = str(v) if not isinstance(v, str) else v
             srv_cfg['env'] = resolved_env
 
+        if _kusto_database_locked and "kusto-mcp-server" in mcp_servers:
+            kusto_env = mcp_servers["kusto-mcp-server"].setdefault("env", {})
+            locked_db = kusto_env.get("KUSTO_DATABASE") or _get_locked_kusto_database()
+            if locked_db:
+                kusto_env["KUSTO_DATABASE"] = locked_db
+            kusto_env["KUSTO_DATABASE_LOCKED"] = "1"
+
         # Inject cached Kusto token if kusto-mcp-server is being configured
         mcp_servers = _inject_kusto_token(mcp_servers)
+        _capture_active_kusto_env(mcp_servers)
 
         # Restart ACP client with new MCP config
         old_path = acp_client.copilot_path if acp_client else "copilot"
@@ -2002,6 +2237,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 
 def main():
+    global _bridge_bind_address
     default_port = 8888
     env_port = os.environ.get("EVA_ACP_PORT", "").strip()
     if env_port:
@@ -2012,7 +2248,8 @@ def main():
 
     parser = argparse.ArgumentParser(description="Eva ACP Bridge Server")
     parser.add_argument("--port", type=int, default=default_port, help="HTTP server port (default: 8888 or EVA_ACP_PORT)")
-    parser.add_argument("--bind", default="127.0.0.1", help="Bind address (default: 127.0.0.1, use 0.0.0.0 for LAN access)")
+    # The Kusto seed endpoint is refused unless this bind address is loopback.
+    parser.add_argument("--bind", default="127.0.0.1", help="Bind address (default: 127.0.0.1, use 0.0.0.0 for LAN access; seed endpoint is disabled off loopback)")
     parser.add_argument("--copilot-path", default="copilot", help="Path to copilot CLI binary")
     parser.add_argument("--cwd", default=os.getcwd(), help="Working directory for ACP session")
     parser.add_argument("--model", default=None, help="Default AI model (e.g. claude-sonnet-4.6, gpt-5.2)")
@@ -2023,6 +2260,7 @@ def main():
     parser.add_argument("--kusto-cluster", default="", help="Kusto cluster URL")
     parser.add_argument("--kusto-database", default="", help="Default Kusto database name")
     args = parser.parse_args()
+    _bridge_bind_address = args.bind
 
     # Build MCP config
     mcp_config = {}
@@ -2066,6 +2304,8 @@ def main():
             kusto_env["KUSTO_CLUSTER_URL"] = args.kusto_cluster
         if args.kusto_database:
             kusto_env["KUSTO_DATABASE"] = args.kusto_database
+        if _kusto_database_locked:
+            kusto_env["KUSTO_DATABASE_LOCKED"] = "1"
 
         # Pre-fetch Kusto token so the MCP subprocess doesn't need interactive auth
         try:
@@ -2133,6 +2373,14 @@ def main():
         }
         print(f"[Bridge] Kusto MCP Server enabled (cluster: {args.kusto_cluster or 'from tool params'})")
 
+    if _kusto_database_locked and "kusto-mcp-server" in mcp_config:
+        kusto_env = mcp_config["kusto-mcp-server"].setdefault("env", {})
+        locked_db = kusto_env.get("KUSTO_DATABASE") or _get_locked_kusto_database()
+        if locked_db:
+            kusto_env["KUSTO_DATABASE"] = locked_db
+        kusto_env["KUSTO_DATABASE_LOCKED"] = "1"
+    _capture_active_kusto_env(mcp_config)
+
     global acp_client
     print(f"[Bridge] Starting ACP bridge on port {args.port}...")
     print(f"[Bridge] Copilot CLI: {args.copilot_path}")
@@ -2159,13 +2407,13 @@ def main():
         print(f"[Bridge] Cognition layer ENABLED (memory injection + reflection)")
         print(f"[Bridge] Cognition launch scope: {_cognition_launch_id} (since {_cognition_launch_iso})")
         # Write SelfState on startup
-        cluster = mcp_config.get("kusto-mcp-server", {}).get("env", {}).get("KUSTO_CLUSTER_URL", "")
-        if cluster:
+        cluster, startup_db = _get_kusto_config()
+        if cluster and startup_db:
             now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
             selfstate_cols = ["Timestamp", "Capability", "Status", "Details"]
             capabilities = [
                 {"Timestamp": now, "Capability": "kusto_access", "Status": "active",
-                 "Details": json.dumps({"cluster": cluster, "database": "Eva"})},
+                 "Details": json.dumps({"cluster": cluster, "database": startup_db})},
                 {"Timestamp": now, "Capability": "acp_bridge", "Status": "active",
                  "Details": json.dumps({"model": args.model or "default", "port": args.port})},
                 {"Timestamp": now, "Capability": "cognition", "Status": "active",
@@ -2182,7 +2430,7 @@ def main():
             for srv in mcp_config:
                 capabilities.append({"Timestamp": now, "Capability": f"mcp_{srv}",
                                      "Status": "active", "Details": "{}"})
-            if _kusto_ingest_direct(cluster, "Eva", "SelfState", selfstate_cols, capabilities):
+            if _kusto_ingest_direct(cluster, startup_db, "SelfState", selfstate_cols, capabilities):
                 print(f"[Bridge] SelfState written ({len(capabilities)} capabilities)")
             else:
                 print("[Bridge] SelfState write failed (continuing startup)")
@@ -2197,6 +2445,7 @@ def main():
     print(f"  GET  /v1/models             — List available models")
     print(f"  GET  /v1/mcp                — MCP server status")
     print(f"  POST /v1/mcp/configure      — Configure MCP servers (hot-reload)")
+    print(f"  POST /v1/kusto/seed         - Apply Eva Kusto schema seed")
     print(f"  GET  /health                — Health check")
     print()
 

--- a/tools/eva_seed.kql
+++ b/tools/eva_seed.kql
@@ -116,14 +116,19 @@ Empathy,0.6
 
 // ── Table: Reflections ────────────────────────────────────────────
 // Eva's self-reflections triggered by significant interactions.
+// 2026-05: Reflections schema realigned to writer columns (Timestamp, Trigger,
+// Observation, ActionTaken, Effectiveness). For existing databases run
+// `.drop table Reflections ifexists` before applying this seed.
 .create-merge table Reflections (
-    Reflection: string,
+    Timestamp: datetime,
     Trigger: string,
-    Timestamp: datetime
+    Observation: string,
+    ActionTaken: string,
+    Effectiveness: string
 )
 
 .ingest inline into table Reflections <|
-I was just created with a new memory database. I look forward to learning about my user and building a meaningful relationship.,Initial seed,2026-01-01T00:00:00Z
+2026-01-01T00:00:00Z,Initial seed,I was just created with a new memory database. I look forward to learning about my user and building a meaningful relationship.,seed,0.0
 
 // ── Table: HeuristicsIndex ────────────────────────────────────────
 // Pattern tracking — entities mentioned across conversations.

--- a/tools/kusto_mcp.py
+++ b/tools/kusto_mcp.py
@@ -61,7 +61,7 @@ class KustoMCPServer:
                     },
                     "database": {
                         "type": "string",
-                        "description": "Database name to query. Uses KUSTO_DATABASE env if not provided."
+                        "description": "Database name to query. Uses KUSTO_DATABASE env if not provided. When KUSTO_DATABASE_LOCKED is set, this argument is ignored and KUSTO_DATABASE is used."
                     },
                     "cluster_url": {
                         "type": "string",
@@ -79,7 +79,7 @@ class KustoMCPServer:
                 "properties": {
                     "database": {
                         "type": "string",
-                        "description": "Database name. Uses KUSTO_DATABASE env if not provided."
+                        "description": "Database name. Uses KUSTO_DATABASE env if not provided. When KUSTO_DATABASE_LOCKED is set, this argument is ignored and KUSTO_DATABASE is used."
                     },
                     "cluster_url": {
                         "type": "string",
@@ -100,7 +100,7 @@ class KustoMCPServer:
                     },
                     "database": {
                         "type": "string",
-                        "description": "Database name. Uses KUSTO_DATABASE env if not provided."
+                        "description": "Database name. Uses KUSTO_DATABASE env if not provided. When KUSTO_DATABASE_LOCKED is set, this argument is ignored and KUSTO_DATABASE is used."
                     },
                     "cluster_url": {
                         "type": "string",
@@ -126,7 +126,7 @@ class KustoMCPServer:
                     },
                     "database": {
                         "type": "string",
-                        "description": "Database name. Uses KUSTO_DATABASE env if not provided."
+                        "description": "Database name. Uses KUSTO_DATABASE env if not provided. When KUSTO_DATABASE_LOCKED is set, this argument is ignored and KUSTO_DATABASE is used."
                     },
                     "cluster_url": {
                         "type": "string",
@@ -153,7 +153,7 @@ class KustoMCPServer:
                     },
                     "database": {
                         "type": "string",
-                        "description": "Database name. Uses KUSTO_DATABASE env if not provided."
+                        "description": "Database name. Uses KUSTO_DATABASE env if not provided. When KUSTO_DATABASE_LOCKED is set, this argument is ignored and KUSTO_DATABASE is used."
                     },
                     "cluster_url": {
                         "type": "string",
@@ -224,6 +224,8 @@ class KustoMCPServer:
     def __init__(self):
         self.cluster_url = os.environ.get("KUSTO_CLUSTER_URL", "")
         self.default_database = os.environ.get("KUSTO_DATABASE", "")
+        database_locked = os.environ.get("KUSTO_DATABASE_LOCKED", "").strip().lower()
+        self.database_locked = database_locked in ("1", "true", "yes")
         self._credential = None
         self._token = None
         self._lock = threading.Lock()
@@ -349,7 +351,18 @@ class KustoMCPServer:
 
     def _resolve_database(self, args):
         """Resolve database name from args or environment."""
+        if self.database_locked:
+            return self.default_database
         return args.get("database", "") or self.default_database
+
+    def _resolve_eva_database(self, args):
+        """Resolve Eva tool database while preserving locked mode."""
+        database = self._resolve_database(args)
+        if database:
+            return database, None
+        if self.database_locked:
+            return "", "Error: database name required. Set KUSTO_DATABASE in locked mode."
+        return "Eva", None
 
     def _kusto_query(self, cluster_url, database, query, is_mgmt=False):
         """Execute a Kusto query and return formatted results."""
@@ -435,6 +448,10 @@ class KustoMCPServer:
             return f"Error: {str(e)}"
 
     def _tool_list_databases(self, args):
+        if self.database_locked:
+            if not self.default_database:
+                return "Error: database name required. Set KUSTO_DATABASE in locked mode."
+            return "DatabaseName\n------------\n" + self.default_database
         cluster_url, err = self._resolve_cluster(args)
         if err:
             return err
@@ -573,7 +590,9 @@ class KustoMCPServer:
         cluster_url, err = self._resolve_cluster(args)
         if err:
             return err
-        database = self._resolve_database(args) or "Eva"
+        database, err = self._resolve_eva_database(args)
+        if err:
+            return err
         entity = args.get("entity", "")
         if not entity:
             return "Error: 'entity' parameter is required."
@@ -590,7 +609,9 @@ class KustoMCPServer:
         cluster_url, err = self._resolve_cluster(args)
         if err:
             return err
-        database = self._resolve_database(args) or "Eva"
+        database, err = self._resolve_eva_database(args)
+        if err:
+            return err
         # Get latest emotion state
         current = self._kusto_query(cluster_url, database, "EmotionState | order by Timestamp desc | take 1")
         # Get baseline
@@ -602,7 +623,9 @@ class KustoMCPServer:
         cluster_url, err = self._resolve_cluster(args)
         if err:
             return err
-        database = self._resolve_database(args) or "Eva"
+        database, err = self._resolve_eva_database(args)
+        if err:
+            return err
         try:
             limit = int(args.get("limit", 5))
         except (TypeError, ValueError):
@@ -614,7 +637,9 @@ class KustoMCPServer:
         cluster_url, err = self._resolve_cluster(args)
         if err:
             return err
-        database = self._resolve_database(args) or "Eva"
+        database, err = self._resolve_eva_database(args)
+        if err:
+            return err
         try:
             limit = int(args.get("limit", 5))
         except (TypeError, ValueError):
@@ -638,6 +663,8 @@ class KustoMCPServer:
         self._log("Kusto MCP Server starting...")
         self._log(f"Cluster: {self.cluster_url or '(not set — will use tool parameter)'}")
         self._log(f"Database: {self.default_database or '(not set — will use tool parameter)'}")
+        if self.database_locked:
+            self._log(f"Database locked to: {self.default_database or '(not set)'}")
 
         for line in sys.stdin:
             line = line.strip()

--- a/tools/test_static.py
+++ b/tools/test_static.py
@@ -275,6 +275,11 @@ def test_model_selector():
     else:
         report("model_eva_label", False, "AIG option should reference 'Eva'")
 
+    aig_match = re.search(r'<select id="selAIGBackend"[^>]*>(.*?)</select>', html, re.DOTALL)
+    aig_values = re.findall(r'value="([^"]+)"', aig_match.group(1)) if aig_match else []
+    report("aig_backend_lmstudio_option", "lmstudio" in aig_values,
+           "missing" if "lmstudio" not in aig_values else "")
+
 
 # ═══════════════════════════════════════════════════════════════════
 #  Section 6: JavaScript Function Routing
@@ -291,6 +296,8 @@ def test_js_routing_functions():
         "dalle3Send": "core/js/dalle3.js",
         "renderEvaResponse": "core/js/options.js",
         "getSystemPrompt": "core/js/options.js",
+        "getLmStudioBaseUrl": "core/js/options.js",
+        "getLmStudioModel": "core/js/options.js",
     }
     for fn, expected_file in required.items():
         if not os.path.isfile(expected_file):

--- a/tools/test_static.py
+++ b/tools/test_static.py
@@ -145,6 +145,32 @@ def test_python_syntax():
             report(f"python_syntax:{py}", False, str(e))
 
 
+def test_artifact_filename_validation():
+    """Generated artifact filenames accept only safe local names."""
+    spec = importlib.util.spec_from_file_location("acp_bridge", "tools/acp_bridge.py")
+    if spec is None or spec.loader is None:
+        report("artifact_name_validator_import", False, "could not load tools/acp_bridge.py")
+        return
+    acp_bridge = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(acp_bridge)
+
+    cases = [
+        ("out.pdf", True),
+        ("a-b_c.1.txt", True),
+        ("../etc/passwd", False),
+        (".hidden", False),
+        (".", False),
+        ("..", False),
+        ("a/b", False),
+        ("", False),
+        ("x" * 129, False),
+        ("x" * 128, True),
+    ]
+    for name, expected in cases:
+        label = name if name else "empty"
+        report(f"artifact_name:{label}", acp_bridge._valid_artifact_name(name) is expected)
+
+
 # ═══════════════════════════════════════════════════════════════════
 #  Section 4: Kusto Ingest CSV Logic (Unit Tests)
 # ═══════════════════════════════════════════════════════════════════
@@ -321,7 +347,7 @@ def main():
     sections = [
         ("File Integrity", [test_required_files, test_no_secrets_committed]),
         ("Config Safety", [test_config_example_clean, test_no_hardcoded_keys]),
-        ("Python Integrity", [test_python_syntax]),
+        ("Python Integrity", [test_python_syntax, test_artifact_filename_validation]),
         ("Kusto CSV Logic", [test_csv_quoting_logic]),
         ("HTML Model Selector", [test_model_selector]),
         ("JS Routing Functions", [test_js_routing_functions]),


### PR DESCRIPTION
This pull request introduces significant improvements to Eva's standalone and web UI capabilities, with a focus on enhanced local deployment, user experience, and backend configurability. The main highlights include new standalone build documentation, expanded model and TTS engine support, improved Kusto (memory) setup and management, and UI/UX refinements for both end-users and developers.

**Standalone/Electron and Build Support:**
- Added a new `standalone/README.md` documenting the Electron-based standalone AppImage build, including prerequisites, build, and runtime notes. Standalone mode now starts its own ACP bridge and exposes Eva-only functionality, with the bridge URL injected into the renderer.
- Updated `README-2.md` to document planned macOS (signed/notarized) and Windows standalone builds, with technical notes on signing, distribution, and configuration.

**Backend and TTS Engine Flexibility:**
- Expanded TTS engine selection in the UI and documentation: OpenAI TTS is now the default, with Browser, Bark, and Amazon Polly as options. UI dropdowns and feature lists updated accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R66) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R195-R196)
- Added LM Studio as an optional backend for both Eva and cognition, with UI controls for base URL and model name, and updated backend routing logic to support these settings. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R300-R311) [[2]](diffhunk://#diff-ad07f42094c3dec15dff5256b0db4e0113aab596906f9a398a03f81abf25ca0eR176-R177) [[3]](diffhunk://#diff-68022e80149d15a6091aa5634f9830f3434433ba6c648fb9a0fc588e9a9fab06L333-R336)

**Memory, Kusto, and Artifact Management:**
- Added UI and logic for seeding the Eva schema into Azure Data Explorer (Kusto) from Settings, including status reporting, input validation, and confirmation prompts. [[1]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR455-R572) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R490-R528) [[3]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR637-R649)
- Added a "Purge Artifacts" button and logic to delete generated files (PDFs, CSVs, etc.) from disk, with status feedback in the Settings panel. [[1]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR455-R572) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R490-R528) [[3]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR637-R649)

**Standalone Mode Detection and Integration:**
- Implemented detection for standalone mode, with bridge URL injection and conditional UI/logic changes (e.g., disabling certain network discovery or settings in standalone). [[1]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR21-R32) [[2]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR50) [[3]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR61) [[4]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR431)

**UI/UX and Miscellaneous Improvements:**
- Improved Eva theme chat badge positioning for better visibility.
- Ensured last assistant response is synced globally for features like Auto Speak.
- Minor content and documentation updates across `README.md` and the web UI.

These changes collectively make Eva more robust in standalone deployments, more flexible for local and cloud backends, and easier to administer for end users.

**References:**  
[[1]](diffhunk://#diff-7791f5c215c18f7e52873a5c8da37c76ecf97db053b8122bafc77d570d5ca585R1-R54) [[2]](diffhunk://#diff-84dec6309ccac1bb77195d4ea4896bf6f2a98c0fb19cf7ecffc507903920c1f2R394-R395) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R66) [[4]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R195-R196) [[5]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R300-R311) [[6]](diffhunk://#diff-ad07f42094c3dec15dff5256b0db4e0113aab596906f9a398a03f81abf25ca0eR176-R177) [[7]](diffhunk://#diff-68022e80149d15a6091aa5634f9830f3434433ba6c648fb9a0fc588e9a9fab06L333-R336) [[8]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR455-R572) [[9]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R490-R528) [[10]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR637-R649) [[11]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR21-R32) [[12]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR50) [[13]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR61) [[14]](diffhunk://#diff-81c8e80d05f995bc9c2bc840c25ed6b893fa7c2ff9c7c7d7a0cdab09b3e1757fR431) [[15]](diffhunk://#diff-9a212b2c42dd2146d65098442a688c99b454ba005622c87ee3fda79550009dc6R869-R880) [[16]](diffhunk://#diff-717f2ade08eebb4df7fef23f54716e206e58a6700842c3e3b0cfe51a96f3cf92R92-R97)