### PR TITLE
Proactive alerts/notifications and voice view overhaul

### DIFF
--- a/core/js/options.js
+++ b/core/js/options.js
@@ -558,6 +558,7 @@ function backgroundJobLabel(jobType) {
     case 'sec_filing_watch': return 'SEC filing watch';
     case 'space_weather_alert': return 'Space weather alert';
     case 'research_deepdive': return 'Research deep-dive';
+    case 'alert_watch': return 'Alert watch';
     default: return jobType ? String(jobType) : 'Background proposal';
   }
 }
@@ -796,6 +797,303 @@ function initBackground() {
   if (refreshButton) refreshButton.addEventListener('click', function() { loadBackgroundData(false); });
   renderBackgroundAll();
   loadBackgroundData(true);
+}
+
+// ---------------------------------------------------------------------------
+// Proactive notifications — poll the bridge and surface findings in the chat
+// ---------------------------------------------------------------------------
+var _notifState = { polling: false, timer: null, intervalMs: 60000 };
+
+function injectProactiveBubble(notif) {
+  var txtOutput = document.getElementById('txtOutput');
+  if (!txtOutput) return;
+  if (typeof hideEvaWelcome === 'function') hideEvaWelcome();
+  var title = escapeHtml(String(notif.title || 'Eva'));
+  var body = escapeHtml(String(notif.body || '')).replace(/\n/g, '<br>');
+  var bubble =
+    '<div class="chat-bubble eva-bubble eva-proactive">' +
+    '<span class="eva">Eva:</span> ' +
+    '<span class="eva-proactive-badge">Proactive</span> ' +
+    '<strong>' + title + '</strong>' +
+    '<div class="md">' + body + '</div></div>';
+  txtOutput.innerHTML += bubble;
+  txtOutput.scrollTop = txtOutput.scrollHeight;
+}
+
+async function pollNotifications() {
+  if (_notifState.polling) return;
+  _notifState.polling = true;
+  try {
+    var options = { method: 'GET' };
+    if (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) {
+      options.signal = AbortSignal.timeout(4000);
+    }
+    var data = await backgroundBridgeRequest('/v1/notifications?unseen_only=1&limit=10', options);
+    var items = (data && Array.isArray(data.notifications)) ? data.notifications : [];
+    if (!items.length) return;
+    var seenIds = [];
+    var voiceText = [];
+    items.forEach(function(notif) {
+      injectProactiveBubble(notif);
+      var channels = Array.isArray(notif.channels) ? notif.channels : ['chat'];
+      if (channels.indexOf('voice') !== -1 && notif.body) {
+        voiceText.push(String(notif.title || '') + '. ' + String(notif.body || ''));
+      }
+      if (notif.id) seenIds.push(notif.id);
+    });
+    // Speak queued voice notifications one combined utterance to avoid overlap.
+    if (voiceText.length && typeof speakText === 'function') {
+      try { speakText(voiceText.join('. ')); } catch (_) {}
+    }
+    if (seenIds.length) {
+      try {
+        await backgroundBridgeRequest('/v1/notifications/seen', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids: seenIds })
+        });
+      } catch (_) {}
+    }
+  } catch (_) {
+    // Bridge unreachable or notifications unavailable; stay quiet and retry next tick.
+  } finally {
+    _notifState.polling = false;
+  }
+}
+
+function initNotifications() {
+  if (_notifState.timer) return;
+  // First poll shortly after load, then on a steady cadence.
+  setTimeout(pollNotifications, 8000);
+  _notifState.timer = setInterval(pollNotifications, _notifState.intervalMs);
+}
+
+// ---------------------------------------------------------------------------
+// Alerts — user-defined watches the background loop evaluates each cycle
+// ---------------------------------------------------------------------------
+var _alertsState = { alerts: [], settings: {} };
+
+function alertTypeLabel(type) {
+  switch (String(type || '')) {
+    case 'keyword_watch': return 'Topic watch';
+    case 'research_question': return 'Research question';
+    case 'sec_filing': return 'SEC filings';
+    case 'weather': return 'Weather';
+    case 'space_weather': return 'Space weather';
+    default: return type || 'Alert';
+  }
+}
+
+// The single primary input is relabeled per type; weather adds a condition field.
+function updateAlertParamFields() {
+  var type = (document.getElementById('alertType') || {}).value || 'keyword_watch';
+  var topicWrap = document.getElementById('alertParamTopicWrap');
+  var topicLabel = document.getElementById('alertParamTopicLabel');
+  var topicInput = document.getElementById('alertParamTopic');
+  var condWrap = document.getElementById('alertParamConditionWrap');
+  var showTopic = true, showCond = false, label = 'Topic to watch', ph = '';
+  switch (type) {
+    case 'keyword_watch': label = 'Topic to watch'; ph = 'e.g. new OpenAI model releases'; break;
+    case 'research_question': label = 'Question to track'; ph = 'e.g. has the Fed changed interest rates?'; break;
+    case 'sec_filing': label = 'Ticker symbols (comma separated)'; ph = 'e.g. AAPL, MSFT'; break;
+    case 'weather': label = 'Location'; ph = 'e.g. Seattle, WA'; showCond = true; break;
+    case 'space_weather': showTopic = false; break;
+  }
+  if (topicWrap) topicWrap.style.display = showTopic ? '' : 'none';
+  if (topicLabel) topicLabel.textContent = label;
+  if (topicInput) topicInput.placeholder = ph;
+  if (condWrap) condWrap.style.display = showCond ? '' : 'none';
+}
+
+function buildAlertParams(type, topicVal, condVal) {
+  switch (type) {
+    case 'keyword_watch': return { topic: topicVal };
+    case 'research_question': return { question: topicVal };
+    case 'sec_filing': return { symbols: topicVal };
+    case 'weather': return { location: topicVal, condition: condVal };
+    case 'space_weather': return {};
+    default: return {};
+  }
+}
+
+function renderAlertsList() {
+  var listEl = document.getElementById('alertsList');
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  if (!_alertsState.alerts.length) {
+    var empty = document.createElement('div');
+    empty.className = 'auth-note';
+    empty.textContent = 'No alerts yet. Add one above to have Eva watch for you.';
+    listEl.appendChild(empty);
+    return;
+  }
+  _alertsState.alerts.forEach(function(rule) {
+    var row = document.createElement('div');
+    row.className = 'background-row';
+    var head = document.createElement('div');
+    head.className = 'background-row-head';
+    var title = document.createElement('div');
+    title.className = 'background-title';
+    title.textContent = rule.label + (rule.enabled ? '' : ' (paused)');
+    head.appendChild(title);
+    var actions = document.createElement('div');
+    actions.className = 'background-actions';
+    var toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'auth-toggle background-inline-button';
+    toggleBtn.textContent = rule.enabled ? 'Pause' : 'Resume';
+    toggleBtn.addEventListener('click', function() { toggleAlert(rule.id); });
+    actions.appendChild(toggleBtn);
+    var delBtn = document.createElement('button');
+    delBtn.type = 'button';
+    delBtn.className = 'auth-toggle';
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', function() { deleteAlert(rule.id); });
+    actions.appendChild(delBtn);
+    head.appendChild(actions);
+    row.appendChild(head);
+    var meta = document.createElement('div');
+    meta.className = 'background-meta';
+    var p = rule.params || {};
+    var detail = p.topic || p.question || p.location || (p.symbols ? p.symbols.join(', ') : '') || alertTypeLabel(rule.type);
+    ['Type: ' + alertTypeLabel(rule.type), detail, 'Every ' + Math.round((rule.cooldown_min || 1440) / 60) + 'h',
+     'Via: ' + (rule.channels || []).join(', ')].forEach(function(text) {
+      if (!text) return;
+      var span = document.createElement('span');
+      span.textContent = text;
+      meta.appendChild(span);
+    });
+    row.appendChild(meta);
+    if (rule.last_fired_iso) {
+      var last = document.createElement('div');
+      last.className = 'background-note';
+      last.textContent = 'Last fired: ' + formatGoalDate(rule.last_fired_iso);
+      row.appendChild(last);
+    }
+    listEl.appendChild(row);
+  });
+}
+
+async function loadAlerts() {
+  try {
+    var data = await backgroundBridgeRequest('/v1/alerts', { method: 'GET' });
+    _alertsState.alerts = Array.isArray(data.alerts) ? data.alerts : [];
+    _alertsState.settings = data.settings || {};
+    renderAlertsList();
+    var s = _alertsState.settings;
+    var qs = document.getElementById('alertQuietStart');
+    var qe = document.getElementById('alertQuietEnd');
+    var mph = document.getElementById('alertMaxPerHour');
+    if (qs && typeof s.quiet_hours_start === 'number') qs.value = s.quiet_hours_start;
+    if (qe && typeof s.quiet_hours_end === 'number') qe.value = s.quiet_hours_end;
+    if (mph && typeof s.max_per_hour === 'number') mph.value = s.max_per_hour;
+  } catch (error) {
+    var listEl = document.getElementById('alertsList');
+    if (listEl) listEl.innerHTML = '<div class="auth-note">' + escapeHtml(error.message || 'Alerts unavailable.') + '</div>';
+  }
+}
+
+function readAlertForm() {
+  var type = (document.getElementById('alertType') || {}).value || 'keyword_watch';
+  var label = (document.getElementById('alertLabel') || {}).value || '';
+  var topic = (document.getElementById('alertParamTopic') || {}).value || '';
+  var cond = (document.getElementById('alertParamCondition') || {}).value || '';
+  var cooldownHours = parseInt((document.getElementById('alertCooldown') || {}).value, 10);
+  if (!Number.isInteger(cooldownHours) || cooldownHours < 1) cooldownHours = 24;
+  var channels = [];
+  if ((document.getElementById('alertChannelChat') || {}).checked) channels.push('chat');
+  if ((document.getElementById('alertChannelVoice') || {}).checked) channels.push('voice');
+  if (!channels.length) channels.push('chat');
+  return {
+    type: type,
+    label: label.trim() || alertTypeLabel(type),
+    params: buildAlertParams(type, topic.trim(), cond.trim()),
+    cooldown_min: cooldownHours * 60,
+    channels: channels,
+    enabled: (document.getElementById('alertEnabled') || {}).checked !== false
+  };
+}
+
+async function saveAlert() {
+  var rule = readAlertForm();
+  try {
+    await backgroundBridgeRequest('/v1/alerts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rule)
+    });
+    clearAlertForm();
+    await loadAlerts();
+    setStatus('info', 'Alert saved.');
+  } catch (error) {
+    setStatus('error', error.message || 'Could not save alert.');
+  }
+}
+
+async function toggleAlert(id) {
+  var rule = _alertsState.alerts.filter(function(r) { return r.id === id; })[0];
+  if (!rule) return;
+  rule.enabled = !rule.enabled;
+  try {
+    await backgroundBridgeRequest('/v1/alerts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rule)
+    });
+    await loadAlerts();
+  } catch (error) {
+    setStatus('error', error.message || 'Could not update alert.');
+  }
+}
+
+async function deleteAlert(id) {
+  if (!confirm('Delete this alert?')) return;
+  try {
+    await backgroundBridgeRequest('/v1/alerts/' + encodeURIComponent(id), { method: 'DELETE' });
+    await loadAlerts();
+    setStatus('info', 'Alert deleted.');
+  } catch (error) {
+    setStatus('error', error.message || 'Could not delete alert.');
+  }
+}
+
+async function saveAlertSettings() {
+  var payload = {
+    quiet_hours_start: parseInt((document.getElementById('alertQuietStart') || {}).value, 10),
+    quiet_hours_end: parseInt((document.getElementById('alertQuietEnd') || {}).value, 10),
+    max_per_hour: parseInt((document.getElementById('alertMaxPerHour') || {}).value, 10)
+  };
+  try {
+    await backgroundBridgeRequest('/v1/alerts/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    await loadAlerts();
+    setStatus('info', 'Notification limits saved.');
+  } catch (error) {
+    setStatus('error', error.message || 'Could not save limits.');
+  }
+}
+
+function clearAlertForm() {
+  var ids = ['alertLabel', 'alertParamTopic', 'alertParamCondition'];
+  ids.forEach(function(id) { var el = document.getElementById(id); if (el) el.value = ''; });
+  var cd = document.getElementById('alertCooldown'); if (cd) cd.value = 24;
+  var en = document.getElementById('alertEnabled'); if (en) en.checked = true;
+}
+
+function initAlerts() {
+  var typeSel = document.getElementById('alertType');
+  var saveBtn = document.getElementById('alertSaveButton');
+  var clearBtn = document.getElementById('alertClearButton');
+  var settingsBtn = document.getElementById('alertSettingsSaveButton');
+  if (typeSel) typeSel.addEventListener('change', updateAlertParamFields);
+  if (saveBtn) saveBtn.addEventListener('click', saveAlert);
+  if (clearBtn) clearBtn.addEventListener('click', clearAlertForm);
+  if (settingsBtn) settingsBtn.addEventListener('click', saveAlertSettings);
+  updateAlertParamFields();
+  loadAlerts();
 }
 
 function applyStandaloneSimplifications() {
@@ -1457,6 +1755,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof cogInit === 'function') cogInit();
   if (typeof initGoals === 'function') initGoals();
   if (typeof initBackground === 'function') initBackground();
+  if (typeof initAlerts === 'function') initAlerts();
+  if (typeof initNotifications === 'function') initNotifications();
 
   // Initialize status panel with any pending config/init notes
   setStatus('info', document.getElementById('idText') && document.getElementById('idText').textContent ? document.getElementById('idText').textContent : '');
@@ -1509,6 +1809,8 @@ var _vv = {
   phase: 'idle', // idle | listening | awake | thinking | speaking | error
   recognition: null,
   awakeTimer: null,
+  convoMode: true,        // stay in an active conversation after the wake word
+  convoTimeoutMs: 30000,  // quiet period before dropping back to standby
   lastTranscript: '',
   lastEvaReply: '',
   speakObserver: null,
@@ -1535,6 +1837,16 @@ function openVoiceView() {
   _vv.open = true;
   el.classList.add('open');
   el.setAttribute('aria-hidden', 'false');
+  // Conversation mode: after the wake word, keep listening between turns until a
+  // quiet period elapses. Persisted so the user's choice survives restarts.
+  try {
+    _vv.convoMode = localStorage.getItem('vvConvoMode') !== '0';
+    var savedTimeout = parseInt(localStorage.getItem('vvConvoTimeoutMs'), 10);
+    if (Number.isInteger(savedTimeout) && savedTimeout >= 5000 && savedTimeout <= 300000) {
+      _vv.convoTimeoutMs = savedTimeout;
+    }
+  } catch (e) {}
+  _vvSyncConvoControls();
   _vvSetStatus('idle');
 
   var closeBtn = document.getElementById('voiceViewClose');
@@ -1565,6 +1877,9 @@ function closeVoiceView() {
   }
   if (_vv.speakObserver) { _vv.speakObserver.disconnect(); _vv.speakObserver = null; }
   _vvDetachSpeakStartListeners();
+  if (_vv._watchTimer) { clearTimeout(_vv._watchTimer); _vv._watchTimer = null; }
+  if (_vv._postTextTimer) { clearTimeout(_vv._postTextTimer); _vv._postTextTimer = null; }
+  _vvStopBargeMonitor();
   if (_vv._wasAutoSpeak !== undefined) {
     var autoSpeak = document.getElementById('autoSpeak');
     if (autoSpeak) autoSpeak.checked = _vv._wasAutoSpeak;
@@ -1607,6 +1922,12 @@ function _vvInitParticles() {
       drift: (Math.random() - 0.5) * 0.02
     });
   }
+  // Electrical impulse pools: radial discharges shoot outward from the orb edge
+  // like neural firings; orbit pulses race along the outer rings leaving a
+  // glowing trail. Both are spawned dynamically in the draw loop.
+  _vv.impulses = [];
+  _vv.orbits = [];
+  _vv._lastImpulseT = 0;
 }
 
 // --- HUD data feeds ---
@@ -1688,6 +2009,9 @@ function _vvStartCanvas() {
     if (!_vv.open) return;
     ctx.clearRect(0, 0, w, h);
 
+    if (!_vv.impulses) _vv.impulses = [];
+    if (!_vv.orbits) _vv.orbits = [];
+
     var t = performance.now() / 1000;
     var phase = _vv.phase;
 
@@ -1703,6 +2027,22 @@ function _vvStartCanvas() {
       ttsData = _vv.ttsDataArray;
     }
     var activeData = ttsData || freqData;
+
+    // Band energies drive organic motion and impulse spawning. Voice lives in
+    // the low/mid bins, so we weight those for the overall level.
+    var bass = 0, mid = 0, treble = 0, level = 0;
+    if (activeData && activeData.length) {
+      var an = activeData.length;
+      var bEnd = Math.max(1, Math.floor(an * 0.12));
+      var mEnd = Math.max(bEnd + 1, Math.floor(an * 0.45));
+      var sb = 0; for (var bb = 0; bb < bEnd; bb++) sb += activeData[bb];
+      var sm = 0; for (var bm = bEnd; bm < mEnd; bm++) sm += activeData[bm];
+      var st = 0; for (var bt = mEnd; bt < an; bt++) st += activeData[bt];
+      bass = sb / bEnd / 255;
+      mid = sm / (mEnd - bEnd) / 255;
+      treble = st / (an - mEnd) / 255;
+      level = bass * 0.6 + mid * 0.32 + treble * 0.08;
+    }
 
     // Phase colors
     var hue, sat, light, glowAlpha, ringHue;
@@ -1738,7 +2078,7 @@ function _vvStartCanvas() {
       ctx.moveTo(x1, y1);
       ctx.lineTo(x2, y2);
     }
-    ctx.strokeStyle = col(ringHue, 40, 50, 0.08);
+    ctx.strokeStyle = col(ringHue, 35, 32, 0.04);
     ctx.lineWidth = 0.5;
     ctx.stroke();
     ctx.restore();
@@ -1750,7 +2090,7 @@ function _vvStartCanvas() {
     ctx.beginPath();
     ctx.setLineDash([8, 16]);
     ctx.arc(0, 0, baseR * 1.45, 0, Math.PI * 2);
-    ctx.strokeStyle = col(ringHue, 40, 50, 0.1);
+    ctx.strokeStyle = col(ringHue, 35, 32, 0.05);
     ctx.lineWidth = 0.8;
     ctx.stroke();
     ctx.setLineDash([]);
@@ -1762,7 +2102,7 @@ function _vvStartCanvas() {
     ctx.rotate(t * 0.25);
     ctx.beginPath();
     ctx.arc(0, 0, baseR * 1.2, 0, Math.PI * 2);
-    ctx.strokeStyle = col(ringHue, sat, light, 0.12);
+    ctx.strokeStyle = col(ringHue, sat, light * 0.55, 0.06);
     ctx.lineWidth = 1;
     ctx.stroke();
     // Tick marks every 30 deg
@@ -1771,7 +2111,7 @@ function _vvStartCanvas() {
       ctx.beginPath();
       ctx.moveTo(Math.cos(ta) * baseR * 1.18, Math.sin(ta) * baseR * 1.18);
       ctx.lineTo(Math.cos(ta) * baseR * 1.24, Math.sin(ta) * baseR * 1.24);
-      ctx.strokeStyle = col(ringHue, sat, light, 0.2);
+      ctx.strokeStyle = col(ringHue, sat, light * 0.55, 0.1);
       ctx.lineWidth = d % 3 === 0 ? 1.5 : 0.7;
       ctx.stroke();
     }
@@ -1810,19 +2150,46 @@ function _vvStartCanvas() {
     }
 
     // === Main waveform orb ===
+    // The perimeter is deformed by three overlapping influences so the WHOLE
+    // ring stays alive (no flat arc): (1) traveling harmonic ripples that orbit
+    // the circle continuously, (2) audio energy that is itself rotated around
+    // the ring over time so loud bins sweep around instead of pinning to a
+    // fixed angle, and (3) a gentle breath. This reads as an organic, living
+    // membrane rather than a static spectrum readout.
     var segments = 180;
+    var dataLen = (activeData && activeData.length) ? activeData.length : 0;
+    var usableBins = dataLen ? Math.max(1, Math.floor(dataLen * 0.6)) : 0;
+    var swirl = t * 0.18; // audio sweep rate around the ring
     ctx.beginPath();
     for (var si = 0; si <= segments; si++) {
       var angle = (si / segments) * Math.PI * 2 - Math.PI / 2;
+      var pos = si / segments;
+
+      // Audio energy, rotated around the ring and reflected so there is no seam.
       var amp = 0;
-      if (activeData && activeData.length > 0) {
-        var fi = Math.floor((si / segments) * activeData.length);
-        amp = activeData[fi] / 255;
+      if (usableBins > 0) {
+        var swept = pos + swirl;
+        var frac = swept - Math.floor(swept);          // 0..1 wrapped
+        var refl = frac <= 0.5 ? frac * 2 : (1 - frac) * 2; // 0..1..0, seamless
+        var fi = Math.min(usableBins - 1, Math.floor(refl * usableBins));
+        amp = (activeData[fi] / 255) * (0.22 + level * 0.5);
       }
-      var breathe = Math.sin(t * 1.2 + angle * 3) * 0.015 + Math.sin(t * 0.7 + angle * 7) * 0.008;
-      var pulse = (phase === 'awake' || phase === 'speaking') ? Math.sin(t * 4) * 0.02 : 0;
-      var think = (phase === 'thinking') ? Math.sin(t * 6 + angle * 12) * 0.025 : 0;
-      var r = baseR * (1 + amp * 0.4 + breathe + pulse + think);
+
+      // Traveling harmonic ripples. Different speeds/directions keep every part
+      // of the ring in motion; amplitude swells with audio level but never goes
+      // fully flat, so the orb always breathes.
+      var organic =
+        Math.sin(angle * 3 + t * 1.6) * 0.55 +
+        Math.sin(angle * 5 - t * 1.1) * 0.30 +
+        Math.sin(angle * 8 + t * 2.4) * 0.18 +
+        Math.sin(angle * 13 - t * 3.1) * 0.10;
+      organic *= (0.022 + level * 0.085 + bass * 0.04);
+
+      var breathe = Math.sin(t * 1.2) * 0.012;
+      var pulse = (phase === 'awake' || phase === 'speaking') ? Math.sin(t * 4) * 0.018 : 0;
+      var think = (phase === 'thinking') ? Math.sin(t * 5 + angle * 9) * 0.03 : 0;
+
+      var r = baseR * (1 + amp * 0.4 + organic + breathe + pulse + think);
       var x = cx + Math.cos(angle) * r;
       var y = cy + Math.sin(angle) * r;
       if (si === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
@@ -1847,6 +2214,119 @@ function _vvStartCanvas() {
     ctx.shadowBlur = 60;
     ctx.stroke();
     ctx.shadowBlur = 0;
+
+    // === Electrical impulses ===
+    // Two effects layered for a "the future is now" feel:
+    //   1. Radial discharges: jagged lightning that fires outward from the orb
+    //      surface, like synapses or energy arcing into the field.
+    //   2. Orbit pulses: bright sparks that race along the outer rings leaving a
+    //      fading comet trail, so energy is always traveling through the window.
+    // Spawn rates scale with the phase and live audio level.
+    var dt = Math.min(0.05, Math.max(0.001, t - (_vv._lastT || t)));
+    _vv._lastT = t;
+    var activity = phase === 'speaking' ? (0.2 + level * 1.1)
+                 : phase === 'thinking' ? 0.32
+                 : phase === 'awake' ? 0.16
+                 : phase === 'listening' ? (0.07 + level * 0.5)
+                 : phase === 'error' ? 0.12
+                 : 0.03;
+
+    // Spawn radial discharges.
+    if (_vv.impulses.length < 16 && Math.random() < activity * 0.32) {
+      var ia = Math.random() * Math.PI * 2;
+      var nodes = 5 + Math.floor(Math.random() * 4);
+      var offs = [];
+      for (var ni = 0; ni < nodes; ni++) offs.push((Math.random() - 0.5));
+      _vv.impulses.push({
+        angle: ia,
+        reach: 0.45 + Math.random() * 0.7,   // how far past the orb it travels
+        prog: 0,
+        speed: 1.6 + Math.random() * 1.8,
+        offs: offs,
+        width: 0.8 + Math.random() * 1.2
+      });
+    }
+    // Spawn orbit pulses.
+    if (_vv.orbits.length < 8 && Math.random() < activity * 0.2) {
+      var ringR = (Math.random() < 0.5 ? 1.2 : 1.45) + (Math.random() - 0.5) * 0.1;
+      _vv.orbits.push({
+        angle: Math.random() * Math.PI * 2,
+        radius: ringR,
+        dir: Math.random() < 0.5 ? 1 : -1,
+        speed: 1.4 + Math.random() * 1.8,
+        prog: 0,
+        life: 0.7 + Math.random() * 0.6
+      });
+    }
+
+    // Draw + update radial discharges.
+    for (var di = _vv.impulses.length - 1; di >= 0; di--) {
+      var im = _vv.impulses[di];
+      im.prog += dt * im.speed;
+      if (im.prog >= 1) { _vv.impulses.splice(di, 1); continue; }
+      var headLen = baseR * (0.04 + im.reach * im.prog);
+      var startR = baseR * (1.0 + 0.02 * Math.sin(t * 4 + im.angle));
+      var ca = Math.cos(im.angle), sa = Math.sin(im.angle);
+      var px0 = cx + ca * startR, py0 = cy + sa * startR;
+      var perpX = -sa, perpY = ca;
+      var seg = im.offs.length;
+      var fade = Math.sin(Math.PI * im.prog); // ramp in then out
+      ctx.beginPath();
+      ctx.moveTo(px0, py0);
+      for (var ii = 0; ii < seg; ii++) {
+        var frac2 = (ii + 1) / seg;
+        var rr = startR + headLen * frac2;
+        var jitter = im.offs[ii] * 10 * (1 - frac2) * (0.6 + level);
+        var jx = cx + ca * rr + perpX * jitter;
+        var jy = cy + sa * rr + perpY * jitter;
+        ctx.lineTo(jx, jy);
+      }
+      ctx.strokeStyle = col(hue, sat - 5, light + 25, 0.5 * fade);
+      ctx.lineWidth = im.width;
+      ctx.shadowColor = col(hue, sat, light + 15, 0.7 * fade);
+      ctx.shadowBlur = 12;
+      ctx.stroke();
+      // Bright head spark.
+      var hx = cx + ca * (startR + headLen) + perpX * im.offs[seg - 1] * 4;
+      var hy = cy + sa * (startR + headLen) + perpY * im.offs[seg - 1] * 4;
+      ctx.beginPath();
+      ctx.arc(hx, hy, im.width * 1.3, 0, Math.PI * 2);
+      ctx.fillStyle = col(hue, sat - 15, 90, 0.8 * fade);
+      ctx.fill();
+      ctx.shadowBlur = 0;
+    }
+
+    // Draw + update orbit pulses (comet trails along the outer rings).
+    for (var oi = _vv.orbits.length - 1; oi >= 0; oi--) {
+      var ob = _vv.orbits[oi];
+      ob.prog += dt * (ob.speed / 6);
+      if (ob.prog >= ob.life) { _vv.orbits.splice(oi, 1); continue; }
+      var oFade = Math.sin(Math.PI * (ob.prog / ob.life));
+      var orbR = baseR * ob.radius;
+      var headA = ob.angle + ob.dir * ob.prog * 4.2;
+      var trail = 14;
+      for (var ti = 0; ti < trail; ti++) {
+        var ta2 = headA - ob.dir * ti * 0.045;
+        var tAlpha = oFade * (1 - ti / trail) * 0.6;
+        if (tAlpha <= 0.01) continue;
+        var tx = cx + Math.cos(ta2) * orbR;
+        var ty = cy + Math.sin(ta2) * orbR;
+        ctx.beginPath();
+        ctx.arc(tx, ty, (1 - ti / trail) * 1.8 + 0.3, 0, Math.PI * 2);
+        ctx.fillStyle = col(ringHue, sat, light + 25, tAlpha);
+        ctx.fill();
+      }
+      // Bright head with glow.
+      var ohx = cx + Math.cos(headA) * orbR;
+      var ohy = cy + Math.sin(headA) * orbR;
+      ctx.beginPath();
+      ctx.arc(ohx, ohy, 2.2, 0, Math.PI * 2);
+      ctx.fillStyle = col(ringHue, sat - 10, 92, 0.85 * oFade);
+      ctx.shadowColor = col(ringHue, sat, light + 20, 0.8 * oFade);
+      ctx.shadowBlur = 14;
+      ctx.fill();
+      ctx.shadowBlur = 0;
+    }
 
     // === Inner ring (heartbeat) ===
     var innerPulse = 0.55 + Math.sin(t * 2) * 0.02;
@@ -1922,11 +2402,18 @@ function _vvStartWaveBar() {
     for (var i = 0; i < bars; i++) {
       var val = 0;
       if (activeData && activeData.length > 0) {
-        var fi = Math.floor((i / bars) * activeData.length);
-        val = activeData[fi] / 255;
+        // Compress sampling toward the low/mid bins (where voice energy lives)
+        // so the bars spread the motion across the whole bar instead of leaving
+        // the high-frequency right side dead.
+        var norm = i / bars;
+        var curved = Math.pow(norm, 1.8);
+        var fi = Math.floor(curved * activeData.length * 0.6);
+        val = activeData[Math.min(activeData.length - 1, fi)] / 255;
       }
-      // Subtle idle animation
-      if (val < 0.01) val = Math.abs(Math.sin(t * 0.8 + i * 0.15)) * 0.03;
+      // Always-alive traveling shimmer so the bar feels organic even in silence.
+      var shimmer = (Math.sin(t * 1.6 - i * 0.22) * 0.5 + 0.5) * 0.04
+                  + Math.abs(Math.sin(t * 0.8 + i * 0.15)) * 0.02;
+      val = Math.max(val, shimmer);
 
       var barH = val * mid * 0.85;
       var x = i * barW + 1;
@@ -1966,7 +2453,11 @@ function _vvStartMicAnalyser() {
   var AudioCtx = window.AudioContext || window.webkitAudioContext;
   if (!AudioCtx) return Promise.resolve();
 
-  return navigator.mediaDevices.getUserMedia({ audio: true }).then(function(stream) {
+  // Echo cancellation is what makes barge-in possible: it removes Eva's own TTS
+  // output (played through the speakers) from the mic signal, so the energy the
+  // barge monitor sees while she speaks is mostly the user, not Eva.
+  var constraints = { audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true } };
+  return navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
     _vv.micStream = stream;
     if (!_vv.audioCtx) _vv.audioCtx = new AudioCtx();
     if (_vv.audioCtx.state === 'suspended') _vv.audioCtx.resume();
@@ -2339,8 +2830,159 @@ function _vvWhisperTranscribe(blob) {
 
 // --- Transcript + command handling ---
 
+// Reflect conversation-mode state into the voice-view controls and bind their
+// change handlers (idempotent; safe to call on each open).
+function _vvSyncConvoControls() {
+  var toggle = document.getElementById('vvConvoToggle');
+  var timeoutSel = document.getElementById('vvConvoTimeout');
+  if (toggle) {
+    toggle.checked = !!_vv.convoMode;
+    if (!toggle._vvBound) {
+      toggle._vvBound = true;
+      toggle.addEventListener('change', function() {
+        _vv.convoMode = !!toggle.checked;
+        try { localStorage.setItem('vvConvoMode', _vv.convoMode ? '1' : '0'); } catch (e) {}
+        // Apply immediately if currently idling between turns.
+        if (_vv.open) {
+          if (_vv.convoMode && _vv.phase === 'listening') {
+            _vvEnterAwake(_vv.convoTimeoutMs);
+          } else if (!_vv.convoMode && _vv.phase === 'awake') {
+            if (_vv.awakeTimer) { clearTimeout(_vv.awakeTimer); _vv.awakeTimer = null; }
+            _vvSetStatus('listening');
+          }
+        }
+      });
+    }
+  }
+  if (timeoutSel) {
+    timeoutSel.value = String(_vv.convoTimeoutMs);
+    if (!timeoutSel._vvBound) {
+      timeoutSel._vvBound = true;
+      timeoutSel.addEventListener('change', function() {
+        var ms = parseInt(timeoutSel.value, 10);
+        if (Number.isInteger(ms) && ms >= 5000 && ms <= 300000) {
+          _vv.convoTimeoutMs = ms;
+          try { localStorage.setItem('vvConvoTimeoutMs', String(ms)); } catch (e) {}
+          if (_vv.open && _vv.phase === 'awake') _vvEnterAwake(ms);
+        }
+      });
+    }
+  }
+}
+
+// Enter the 'awake' conversation window. While awake, the user can speak follow
+// ups without repeating the wake word. After timeoutMs of no speech we fall back
+// to 'listening' (standby), which requires saying "Eva" again.
+function _vvEnterAwake(timeoutMs) {
+  _vvSetStatus('awake');
+  if (_vv.awakeTimer) { clearTimeout(_vv.awakeTimer); _vv.awakeTimer = null; }
+  _vv.awakeTimer = setTimeout(function() {
+    _vv.awakeTimer = null;
+    if (_vv.phase === 'awake') _vvSetStatus('listening');
+  }, timeoutMs || 10000);
+}
+
+// Called when a turn completes. In conversation mode Eva stays awake for a
+// follow-up; otherwise she returns to standby and waits for the wake word.
+function _vvAfterTurn() {
+  if (!_vv.open) return;
+  if (!(_vv.recognition || _vv.whisperMode)) { _vvSetStatus('idle'); return; }
+  if (_vv.convoMode) {
+    _vvEnterAwake(_vv.convoTimeoutMs);
+  } else {
+    _vvSetStatus('listening');
+  }
+  if (_vv.whisperMode) _vvWhisperRecord();
+}
+
+// --- Barge-in (interrupt Eva while she speaks) ---
+
+// Hard-stop any TTS playback. Pausing the audio element silences the network
+// voices; cancel() stops the browser SpeechSynthesis engine.
+function _vvStopTTS() {
+  var audio = document.getElementById('audioPlayback');
+  if (audio) {
+    try { audio.pause(); } catch (e) {}
+    try { audio.currentTime = 0; } catch (e) {}
+  }
+  if (window.speechSynthesis) { try { window.speechSynthesis.cancel(); } catch (e) {} }
+}
+
+// Invoked when the barge monitor detects the user talking over Eva. Routes the
+// speaking phase through its finalizer with the barged flag so Eva goes quiet
+// and immediately opens a conversation window to catch the redirect.
+function _vvBargeIn() {
+  if (_vv.phase !== 'speaking') return;
+  if (typeof _vv._finishSpeaking === 'function') {
+    _vv._finishSpeaking(true);
+  }
+}
+
+// After a barge-in, open the conversation window (no wake word needed) and arm
+// capture so the user's redirect is heard right away.
+function _vvAfterBarge() {
+  if (!_vv.open) return;
+  if (!(_vv.recognition || _vv.whisperMode)) { _vvSetStatus('idle'); return; }
+  _vvEnterAwake(_vv.convoTimeoutMs);
+  if (_vv.whisperMode) _vvWhisperRecord();
+}
+
+// Watch the mic during the speaking phase. With echo cancellation removing
+// Eva's own voice, sustained mic energy that also clears the current playback
+// level means the user is talking over her, so we trigger a barge-in. A short
+// startup grace avoids self-triggering on Eva's first syllable.
+function _vvStartBargeMonitor() {
+  _vvStopBargeMonitor();
+  if (!_vv.analyser || !_vv.dataArray) return;
+  var aboveSince = 0;
+  var NEED_MS = 300;   // sustained user speech before interrupting
+  var THRESH = 40;     // min average mic energy (0-255) to consider speech
+  var graceUntil = performance.now() + 700;
+  function loop() {
+    if (_vv.phase !== 'speaking' || !_vv.open || !_vv.analyser) { _vv.bargeRAF = null; return; }
+    _vv.analyser.getByteFrequencyData(_vv.dataArray);
+    var sum = 0;
+    for (var i = 0; i < _vv.dataArray.length; i++) sum += _vv.dataArray[i];
+    var micAvg = sum / _vv.dataArray.length;
+
+    // Current TTS playback level, so the bar to interrupt rises while Eva is
+    // loud and falls in her pauses (belt-and-suspenders alongside AEC).
+    var ttsAvg = 0;
+    if (_vv.ttsAnalyser && _vv.ttsDataArray) {
+      _vv.ttsAnalyser.getByteFrequencyData(_vv.ttsDataArray);
+      var ts = 0;
+      for (var j = 0; j < _vv.ttsDataArray.length; j++) ts += _vv.ttsDataArray[j];
+      ttsAvg = ts / _vv.ttsDataArray.length;
+    }
+
+    var now = performance.now();
+    var isUser = now > graceUntil && micAvg > THRESH && micAvg > (ttsAvg * 0.6 + 10);
+    if (isUser) {
+      if (!aboveSince) aboveSince = now;
+      else if (now - aboveSince >= NEED_MS) { _vv.bargeRAF = null; _vvBargeIn(); return; }
+    } else {
+      aboveSince = 0;
+    }
+    _vv.bargeRAF = requestAnimationFrame(loop);
+  }
+  _vv.bargeRAF = requestAnimationFrame(loop);
+}
+
+function _vvStopBargeMonitor() {
+  if (_vv.bargeRAF) { cancelAnimationFrame(_vv.bargeRAF); _vv.bargeRAF = null; }
+}
+
 function _vvHandleTranscript(transcript) {
-  if (_vv.phase === 'thinking' || _vv.phase === 'speaking') return;
+  // A response is mid-flight: ignore.
+  if (_vv.phase === 'thinking') return;
+  // Spoken interruption while Eva is talking: barge in, then process the phrase
+  // as the redirect. (Whisper mode does not record during speaking, so this
+  // branch is reached only by the Web Speech recognizer; the energy monitor
+  // covers whisper.)
+  if (_vv.phase === 'speaking') {
+    if (!transcript || transcript.trim().length <= 1) return;
+    _vvBargeIn();
+  }
 
   // Show transcript in HUD
   var transcriptEl = document.getElementById('vvTranscript');
@@ -2354,21 +2996,19 @@ function _vvHandleTranscript(transcript) {
     if (command.length > 1) {
       _vvSendCommand(command);
     } else {
-      _vvSetStatus('awake');
-      if (_vv.awakeTimer) clearTimeout(_vv.awakeTimer);
-      _vv.awakeTimer = setTimeout(function() {
-        if (_vv.phase === 'awake') _vvSetStatus('listening');
-      }, 10000);
+      // Wake word only: open the conversation window and wait for the command.
+      _vvEnterAwake(_vv.convoMode ? _vv.convoTimeoutMs : 10000);
     }
     return;
   }
 
   if (_vv.phase === 'awake') {
-    if (_vv.awakeTimer) { clearTimeout(_vv.awakeTimer); _vv.awakeTimer = null; }
     if (transcript.length > 1) {
       _vvSendCommand(transcript);
     } else {
-      _vvSetStatus('listening');
+      // Too short to act on; stay awake and re-arm the standby timer instead of
+      // dropping out of the conversation on a stray noise.
+      _vvEnterAwake(_vv.convoMode ? _vv.convoTimeoutMs : 10000);
     }
   }
 }
@@ -2376,6 +3016,7 @@ function _vvHandleTranscript(transcript) {
 function _vvSendCommand(command) {
   _vv.lastTranscript = command;
   _vv.cmdStart = performance.now();
+  if (_vv.awakeTimer) { clearTimeout(_vv.awakeTimer); _vv.awakeTimer = null; }
   _vvSetStatus('thinking');
   _vvHideAssets();
 
@@ -2401,50 +3042,103 @@ function _vvWatchForResponse() {
 
   if (_vv.speakObserver) { _vv.speakObserver.disconnect(); _vv.speakObserver = null; }
   _vvDetachSpeakStartListeners();
+  if (_vv._watchTimer) { clearTimeout(_vv._watchTimer); _vv._watchTimer = null; }
+  if (_vv._postTextTimer) { clearTimeout(_vv._postTextTimer); _vv._postTextTimer = null; }
 
-  var responded = false;
+  var finished = false;   // the whole turn has resolved
+  var speaking = false;   // real audio/synth playback has started
+  var gotText = false;    // Eva's text response has been observed
   var audio = document.getElementById('audioPlayback');
   var synth = window.speechSynthesis;
 
   function cleanupTriggers() {
     if (_vv.speakObserver) { _vv.speakObserver.disconnect(); _vv.speakObserver = null; }
     _vvDetachSpeakStartListeners();
+    if (_vv._watchTimer) { clearTimeout(_vv._watchTimer); _vv._watchTimer = null; }
+    if (_vv._postTextTimer) { clearTimeout(_vv._postTextTimer); _vv._postTextTimer = null; }
   }
 
-  // Idempotent: whichever signal arrives first (response text seen, audio
-  // element starts playing, or speech synthesis starts) flips us to the
-  // speaking phase. Audio playback is the most reliable trigger because some
-  // providers set lastResponse only after the final DOM mutation, which can
-  // race past the observer and leave the status stuck on PROCESSING.
-  function beginSpeaking() {
-    if (responded || !_vv.open) return;
-    responded = true;
+  function finishToListening() {
+    if (finished || !_vv.open) return;
+    finished = true;
     cleanupTriggers();
+    _vvRestoreAutoSpeak();
+    if (_vv.open) {
+      _vvSetStatus('listening');
+      if (_vv.whisperMode) _vvWhisperRecord();
+    }
+  }
+
+  // Enter the speaking phase ONLY when real audio is heard. The earlier design
+  // flipped to 'speaking' as soon as Eva's text appeared, but TTS (network
+  // voices, or a slow cognition turn that renders text well before audio) can
+  // lag the text by seconds. That produced a green 'speaking' orb with no
+  // sound, which then timed out back to 'listening' just before the real audio
+  // started. Triggering on the actual audio/synth start keeps them in sync.
+  function beginSpeaking() {
+    if (finished || speaking || !_vv.open) return;
+    speaking = true;
+    if (_vv.speakObserver) { _vv.speakObserver.disconnect(); _vv.speakObserver = null; }
+    _vvDetachSpeakStartListeners();
+    if (_vv._watchTimer) { clearTimeout(_vv._watchTimer); _vv._watchTimer = null; }
+    if (_vv._postTextTimer) { clearTimeout(_vv._postTextTimer); _vv._postTextTimer = null; }
 
     var evaResponse = (typeof lastResponse === 'string') ? lastResponse.trim() : '';
     if (evaResponse) _vv.lastEvaReply = evaResponse;
 
     _vvSetStatus('speaking');
     _vvConnectTTSAnalyser();
+    _vvStartBargeMonitor();
 
-    _vvWaitForSpeechEnd(function() {
+    // Single finalizer for the speaking phase, reachable from both the natural
+    // speech-end and a user barge-in. Idempotent so whichever path wins runs the
+    // teardown exactly once.
+    var ended = false;
+    function finishSpeaking(barged) {
+      if (ended) return;
+      ended = true;
+      _vv._finishSpeaking = null;
+      _vvStopBargeMonitor();
+      if (barged) _vvStopTTS();
       _vvDisconnectTTSAnalyser();
+      finished = true;
+      cleanupTriggers();
       _vvRestoreAutoSpeak();
-      if (_vv.open && (_vv.recognition || _vv.whisperMode)) {
-        _vvSetStatus('listening');
-        if (_vv.whisperMode) _vvWhisperRecord();
-      }
-    });
+      if (barged) _vvAfterBarge(); else _vvAfterTurn();
+    }
+    _vv._finishSpeaking = finishSpeaking;
+
+    _vvWaitForSpeechEnd(function() { finishSpeaking(false); });
   }
 
-  _vv.speakObserver = new MutationObserver(function() {
-    if (responded || !_vv.open) return;
+  // Eva's text response arrived. Stay in 'thinking' and wait for audio to begin
+  // (the reliable speaking trigger). If no audio starts within the grace window
+  // the response was effectively silent, so return to listening rather than
+  // showing a speaking phase that never produces sound.
+  function onResponseText() {
+    if (finished || speaking || gotText || !_vv.open) return;
     var evaResponse = (typeof lastResponse === 'string') ? lastResponse.trim() : '';
-    if (evaResponse && evaResponse !== _vv.lastEvaReply) beginSpeaking();
-  });
+    if (!evaResponse || evaResponse === _vv.lastEvaReply) return;
+    gotText = true;
+    _vv.lastEvaReply = evaResponse;
+    if (_vv._watchTimer) { clearTimeout(_vv._watchTimer); _vv._watchTimer = null; }
+    _vv._postTextTimer = setTimeout(function() {
+      _vv._postTextTimer = null;
+      if (!speaking && !finished) {
+        // Text completed but no audio played (silent or disabled TTS). The turn
+        // is still done, so continue the conversation rather than abandoning it.
+        finished = true;
+        cleanupTriggers();
+        _vvRestoreAutoSpeak();
+        _vvAfterTurn();
+      }
+    }, 20000);
+  }
+
+  _vv.speakObserver = new MutationObserver(onResponseText);
   _vv.speakObserver.observe(txtOutput, { childList: true, subtree: true, characterData: true });
 
-  // Audio playback as a fallback/parallel trigger.
+  // Audio playback / synth start are the authoritative speaking triggers.
   _vv._onSpeakStart = function() { beginSpeaking(); };
   if (audio) {
     audio.addEventListener('playing', _vv._onSpeakStart);
@@ -2452,19 +3146,29 @@ function _vvWatchForResponse() {
   }
   if (synth) {
     _vv._synthPoll = setInterval(function() {
-      if (responded || !_vv.open) { clearInterval(_vv._synthPoll); _vv._synthPoll = null; return; }
+      if (finished || !_vv.open) { clearInterval(_vv._synthPoll); _vv._synthPoll = null; return; }
       if (synth.speaking) beginSpeaking();
     }, 200);
   }
 
-  setTimeout(function() {
-    if (!responded && _vv.open) {
-      cleanupTriggers();
-      _vvRestoreAutoSpeak();
-      _vvSetStatus('listening');
-      if (_vv.whisperMode) _vvWhisperRecord();
+  // No-response watchdog. Heavy cognition turns (draft + review on slow models)
+  // can legitimately run for minutes, so while Eva is still 'thinking' and no
+  // text or audio has arrived we keep waiting and re-arm. Once text arrives the
+  // post-text grace above takes over; once audio starts beginSpeaking does. We
+  // only force a recovery here if the phase already moved on or a hard ceiling
+  // is hit (a stuck turn that never produced text or audio).
+  var watchStart = performance.now();
+  var WATCH_ABS_MAX = 600000; // 10 min hard ceiling
+  function watchdog() {
+    _vv._watchTimer = null;
+    if (finished || speaking || gotText || !_vv.open) return;
+    if (_vv.phase === 'thinking' && (performance.now() - watchStart) < WATCH_ABS_MAX) {
+      _vv._watchTimer = setTimeout(watchdog, 10000);
+      return;
     }
-  }, 60000);
+    finishToListening();
+  }
+  _vv._watchTimer = setTimeout(watchdog, 60000);
 }
 
 function _vvDetachSpeakStartListeners() {
@@ -3559,6 +4263,13 @@ function speakText() {
         VoiceId: ""
     };
 
+    // Optional override (e.g. proactive notifications) speaks an arbitrary
+    // string directly, bypassing the lastResponse/transcript extraction so it
+    // never collides with the normal chat auto-speak path.
+    var overrideText = (typeof arguments[0] === 'string' && arguments[0].trim()) ? arguments[0] : '';
+    if (overrideText) {
+      speechParams.Text = sanitizeForSpeech(overrideText);
+    } else
     // Prefer the global `lastResponse` populated by aig.js / copilot.js /
     // gpt-core.js. That string is the clean final response without any
     // cognition-trace markup, which prevents Auto Speak from reading the
@@ -3677,7 +4388,7 @@ function speakText() {
       const barkHost = localStorage.getItem('barkTTSHost') || 'localhost';
       const barkBase = 'https://' + barkHost;
       const url = barkBase + '/send-string';
-      const data = "WOMAN: " + textArr[1];
+      const data = "WOMAN: " + ((typeof textArr !== 'undefined' && textArr[1]) ? textArr[1] : speechParams.Text);
       const xhr = new XMLHttpRequest();
       xhr.responseType = 'blob';
 

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -4246,9 +4246,14 @@ function sanitizeForSpeech(input) {
 }
 
 function speakText() {
+  // Optional override (e.g. proactive notifications) speaks an arbitrary string
+  // directly. Resolve it BEFORE the empty-transcript guard so voice alerts work
+  // on first load or before any chat output exists.
+  var overrideText = (typeof arguments[0] === 'string' && arguments[0].trim()) ? arguments[0] : '';
+
   var txtOutputEl = document.getElementById('txtOutput');
   var sText = txtOutputEl ? txtOutputEl.innerHTML : '';
-    if (sText == "") {
+    if (!overrideText && sText == "") {
         alert("No text to convert to speech!");
         return;
     }
@@ -4266,7 +4271,6 @@ function speakText() {
     // Optional override (e.g. proactive notifications) speaks an arbitrary
     // string directly, bypassing the lastResponse/transcript extraction so it
     // never collides with the normal chat auto-speak path.
-    var overrideText = (typeof arguments[0] === 'string' && arguments[0].trim()) ? arguments[0] : '';
     if (overrideText) {
       speechParams.Text = sanitizeForSpeech(overrideText);
     } else

--- a/core/style.css
+++ b/core/style.css
@@ -1107,6 +1107,25 @@ body.theme-lcars .eva-inline-img {
   border-radius: 4px;
 }
 
+/* Proactive notification bubbles surfaced by the background loop */
+#txtOutput .eva-proactive {
+  border-left: 3px solid #d8a13a;
+  background: rgba(216, 161, 58, 0.06);
+}
+.eva-proactive-badge {
+  display: inline-block;
+  background: #d8a13a;
+  color: #1a1a1a;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 4px;
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+body.theme-lcars #txtOutput .eva-proactive { border-left-color: var(--ld-arctic-ice); }
+
 /* Markdown inside #txtOutput */
 #txtOutput .md h1,
 #txtOutput .md h2,

--- a/core/themes/eva.css
+++ b/core/themes/eva.css
@@ -1060,6 +1060,40 @@ body.theme-eva .cog-badge[data-active="true"] {
   color: rgba(140,120,255,0.45);
 }
 
+/* ── Conversation-mode controls ───────────────────────────── */
+.vv-convo-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  color: rgba(160,180,230,0.55);
+  margin-top: 2px;
+}
+.vv-convo-toggle,
+.vv-convo-timeout {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+.vv-convo-toggle input[type="checkbox"] {
+  accent-color: rgba(140,120,255,0.9);
+  cursor: pointer;
+}
+.vv-convo-timeout select {
+  background: rgba(20,24,40,0.8);
+  color: rgba(180,200,240,0.85);
+  border: 1px solid rgba(120,130,200,0.3);
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 1px 4px;
+  cursor: pointer;
+}
+
 /* ── Voice-mode asset surface ─────────────────────────────── */
 .vv-assets {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -537,6 +537,67 @@
           </div>
         </div>
 
+        <h4 class="settings-subhead">My alerts</h4>
+        <p class="auth-note">Tell Eva what to watch. She checks active alerts each background cycle and speaks up in chat (and aloud) when something new turns up.</p>
+        <div class="mcp-preset background-controls">
+          <div class="auth-field">
+            <label for="alertType">Type</label>
+            <select id="alertType">
+              <option value="keyword_watch">Topic / keyword watch</option>
+              <option value="research_question">Standing research question</option>
+              <option value="sec_filing">SEC filing watch</option>
+              <option value="weather">Weather</option>
+              <option value="space_weather">Space weather</option>
+            </select>
+          </div>
+          <div class="auth-field">
+            <label for="alertLabel">Label</label>
+            <input type="text" id="alertLabel" maxlength="80" placeholder="Short name for this alert">
+          </div>
+          <div class="auth-field" id="alertParamTopicWrap">
+            <label for="alertParamTopic" id="alertParamTopicLabel">Topic to watch</label>
+            <input type="text" id="alertParamTopic" maxlength="240" placeholder="e.g. new OpenAI model releases">
+          </div>
+          <div class="auth-field" id="alertParamConditionWrap" style="display:none;">
+            <label for="alertParamCondition">Alert when (condition)</label>
+            <input type="text" id="alertParamCondition" maxlength="160" placeholder="e.g. rain, snow, or severe warnings">
+          </div>
+          <div class="auth-field">
+            <label for="alertCooldown">Minimum hours between alerts</label>
+            <input type="number" id="alertCooldown" min="1" max="336" step="1" value="24">
+          </div>
+          <div class="background-jobs">
+            <span class="background-jobs-label">Deliver via:</span>
+            <label class="background-toggle-row"><input type="checkbox" id="alertChannelChat" checked> Chat message</label>
+            <label class="background-toggle-row"><input type="checkbox" id="alertChannelVoice" checked> Spoken aloud</label>
+            <label class="background-toggle-row"><input type="checkbox" id="alertEnabled" checked> Enabled</label>
+          </div>
+          <div class="background-actions">
+            <button type="button" class="auth-save" id="alertSaveButton">Add alert</button>
+            <button type="button" class="auth-toggle" id="alertClearButton">Clear form</button>
+          </div>
+        </div>
+        <div id="alertsList" class="background-list"></div>
+
+        <h4 class="settings-subhead">Notification limits</h4>
+        <div class="mcp-preset background-controls">
+          <div class="auth-field">
+            <label for="alertQuietStart">Quiet hours start (0-23, -1 off)</label>
+            <input type="number" id="alertQuietStart" min="-1" max="23" step="1" value="-1">
+          </div>
+          <div class="auth-field">
+            <label for="alertQuietEnd">Quiet hours end (0-23, -1 off)</label>
+            <input type="number" id="alertQuietEnd" min="-1" max="23" step="1" value="-1">
+          </div>
+          <div class="auth-field">
+            <label for="alertMaxPerHour">Max notifications per hour</label>
+            <input type="number" id="alertMaxPerHour" min="1" max="60" step="1" value="4">
+          </div>
+          <div class="background-actions">
+            <button type="button" class="auth-save" id="alertSettingsSaveButton">Save limits</button>
+          </div>
+        </div>
+
         <h4 class="settings-subhead">Recent activity</h4>
         <div id="backgroundActivity" class="background-list"></div>
       </div>
@@ -778,7 +839,24 @@
     <!-- Transcript + waveform bar -->
     <div class="vv-hud-bottom">
       <canvas id="vvWaveBar" class="vv-wave-bar" width="600" height="48"></canvas>
-      <div id="vvHudTelemetry" class="vv-hint vv-telemetry">tap orb to listen &middot; say <em>Eva</em> to wake</div>
+      <div id="vvHudTelemetry" class="vv-hint vv-telemetry">tap orb to listen &middot; say <em>Eva</em> to wake &middot; talk over her to redirect</div>
+      <!-- Conversation mode is on by default (30s standby). Controls kept in the
+           DOM so the saved defaults still drive behavior, but hidden from view. -->
+      <div class="vv-convo-controls" style="display:none;">
+        <label class="vv-convo-toggle" title="Stay in conversation after the wake word so you don't repeat &quot;Eva&quot; each turn">
+          <input type="checkbox" id="vvConvoToggle" checked> Conversation mode
+        </label>
+        <label class="vv-convo-timeout" title="Quiet time before Eva returns to standby and needs the wake word again">
+          standby after
+          <select id="vvConvoTimeout">
+            <option value="15000">15s</option>
+            <option value="30000" selected>30s</option>
+            <option value="60000">1m</option>
+            <option value="120000">2m</option>
+            <option value="300000">5m</option>
+          </select>
+        </label>
+      </div>
     </div>
     <!-- Asset surface: images/media Eva shows while in voice mode -->
     <div id="vvAssets" class="vv-assets" aria-hidden="true">

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -29,6 +29,7 @@ The server exposes a single endpoint:
 import argparse
 import copy
 import datetime
+import hashlib
 import json
 import mimetypes
 import os
@@ -648,6 +649,8 @@ _CONVO_CONTENT_CAP = 8000  # Kusto string columns are unbounded, but cap defensi
 _ARTIFACTS_DIR = os.path.expanduser("~/.config/eva-standalone/artifacts")
 _KUSTO_CLUSTER_CACHE_PATH = os.path.expanduser("~/.config/eva-standalone/kusto_cluster.txt")
 _MCP_CONFIG_CACHE_PATH = os.path.expanduser("~/.config/eva-standalone/mcp_config.json")
+_ALERTS_CONFIG_PATH = os.path.expanduser("~/.config/eva-standalone/alerts.json")
+_NOTIFY_PATH = os.path.expanduser("~/.config/eva-standalone/notifications.jsonl")
 _kusto_table_columns_cache = {}  # (cluster, db, table) -> [columns]
 _kusto_database_locked = _env_truthy("KUSTO_DATABASE_LOCKED") or _env_truthy("EVA_KUSTO_LOCKED")
 _active_kusto_db = os.environ.get("KUSTO_DATABASE", "").strip()
@@ -899,6 +902,7 @@ _BG_JOB_MARKET_SNAPSHOT = "market_snapshot"
 _BG_JOB_SEC_FILINGS = "sec_filing_watch"
 _BG_JOB_SPACE_WEATHER = "space_weather_alert"
 _BG_JOB_RESEARCH_DEEPDIVE = "research_deepdive"
+_BG_JOB_ALERT_WATCH = "alert_watch"
 # Per-job enable switches. All on by default; the loop still respects the
 # global _bg_loop_enabled flag and the recent-activity pause.
 _BG_JOBS_ENABLED = {
@@ -914,6 +918,7 @@ _BG_JOBS_ENABLED = {
     _BG_JOB_SEC_FILINGS: True,
     _BG_JOB_SPACE_WEATHER: True,
     _BG_JOB_RESEARCH_DEEPDIVE: True,
+    _BG_JOB_ALERT_WATCH: True,
 }
 # Target tables the approve/apply path knows how to write.
 _BG_APPLY_TABLES = {"MemorySummaries", "Reflections"}
@@ -1227,6 +1232,343 @@ def _telemetry_summarize(events):
     summary["aig_turn_ms"] = _stats(turn_ms)
     return summary
 
+
+# ---------------------------------------------------------------------------
+# Proactive alerts + notifications
+# ---------------------------------------------------------------------------
+# Two co-operating pieces:
+#   1. A user-defined alert rules store (alerts.json). Each rule names something
+#      the user wants watched (a topic, a company's filings, weather, a standing
+#      research question). The background tick evaluates active rules through the
+#      ACP agent and fires a notification when a rule trips, with per-rule
+#      cooldown and content-hash dedup so the same finding is not repeated.
+#   2. A notification queue (in-memory ring + JSONL) that the front end polls.
+#      New notifications are surfaced as an Eva-authored chat message and, when
+#      the rule asks for it, spoken aloud.
+# Privacy: the rules file holds only labels and watch parameters the user typed;
+# the notification log holds the finding text Eva produced (no keys/tokens). The
+# telemetry mirror records only labels, counts, and decisions.
+
+_ALERT_TYPES = ("sec_filing", "weather", "space_weather", "keyword_watch", "research_question")
+_ALERT_CHANNELS = ("chat", "voice")
+_NOTIFY_RING_MAX = 100
+_NOTIFY_MAX_BYTES = 2 * 1024 * 1024  # rotate notifications.jsonl at ~2MB
+_NOTIFY_CRITICAL_SALIENCE = 0.9      # quiet-hours / rate-cap override threshold
+_alerts_lock = threading.RLock()
+_notify_lock = threading.Lock()
+_notify_ring = []  # recent notification dicts (most recent last)
+
+_DEFAULT_ALERT_SETTINGS = {
+    "quiet_hours_start": -1,  # local hour 0-23 to begin suppression, -1 disables
+    "quiet_hours_end": -1,    # local hour 0-23 to end suppression
+    "max_per_hour": 4,        # cap on surfaced notifications per rolling hour
+    "min_salience": 0.0,      # drop notifications below this score
+}
+
+
+def _alerts_default_doc():
+    return {"alerts": [], "settings": dict(_DEFAULT_ALERT_SETTINGS)}
+
+
+def _load_alerts():
+    """Load the alert rules + settings document. Returns a normalized dict with
+    'alerts' (list) and 'settings' (dict). Never raises."""
+    doc = _alerts_default_doc()
+    try:
+        if os.path.isfile(_ALERTS_CONFIG_PATH):
+            with open(_ALERTS_CONFIG_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                rules = data.get("alerts")
+                if isinstance(rules, list):
+                    doc["alerts"] = [r for r in rules if isinstance(r, dict)]
+                settings = data.get("settings")
+                if isinstance(settings, dict):
+                    for k in _DEFAULT_ALERT_SETTINGS:
+                        if k in settings:
+                            doc["settings"][k] = settings[k]
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"[Bridge] Could not load alerts config: {exc}", file=sys.stderr)
+    return doc
+
+
+def _save_alerts(doc):
+    """Persist the alert rules document atomically. Never raises."""
+    try:
+        os.makedirs(os.path.dirname(_ALERTS_CONFIG_PATH), exist_ok=True)
+        tmp = _ALERTS_CONFIG_PATH + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(doc, f, indent=2)
+        os.replace(tmp, _ALERTS_CONFIG_PATH)
+        return True
+    except (OSError, TypeError) as exc:
+        print(f"[Bridge] Could not save alerts config: {exc}", file=sys.stderr)
+        return False
+
+
+def _alert_clip(value, limit):
+    s = "" if value is None else str(value)
+    s = s.strip()
+    return s if len(s) <= limit else s[:limit]
+
+
+def _sanitize_alert_rule(raw, existing=None):
+    """Validate and normalize a single rule dict from a client request.
+    Returns (rule, error). Generates an id when absent. Preserves server-side
+    bookkeeping (last_fired_iso, last_hash) from an existing rule when updating."""
+    if not isinstance(raw, dict):
+        return None, "rule must be an object"
+    rtype = _alert_clip(raw.get("type"), 32)
+    if rtype not in _ALERT_TYPES:
+        return None, "type must be one of: " + ", ".join(_ALERT_TYPES)
+    label = _alert_clip(raw.get("label"), 80)
+    if not label:
+        return None, "label is required"
+    rid = _alert_clip(raw.get("id"), 64)
+    if rid and not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", rid):
+        return None, "id is invalid"
+    if not rid:
+        rid = "alr-" + uuid.uuid4().hex[:10]
+
+    params_in = raw.get("params") if isinstance(raw.get("params"), dict) else {}
+    params = {}
+    if rtype == "sec_filing":
+        symbols_raw = params_in.get("symbols")
+        if isinstance(symbols_raw, str):
+            symbols_raw = re.split(r"[,\s]+", symbols_raw)
+        symbols = []
+        for sym in (symbols_raw or []):
+            s = _alert_clip(sym, 8).upper()
+            if re.fullmatch(r"[A-Z.]{1,8}", s) and s not in symbols:
+                symbols.append(s)
+        if not symbols:
+            return None, "sec_filing requires at least one ticker symbol"
+        params["symbols"] = symbols[:12]
+    elif rtype == "weather":
+        location = _alert_clip(params_in.get("location"), 80)
+        if not location:
+            return None, "weather requires a location"
+        params["location"] = location
+        params["condition"] = _alert_clip(params_in.get("condition"), 160) or "severe weather, storms, or warnings"
+    elif rtype == "space_weather":
+        params["threshold"] = _alert_clip(params_in.get("threshold"), 40) or "Kp 5+, G1+, R1+, or S1+"
+    elif rtype == "keyword_watch":
+        topic = _alert_clip(params_in.get("topic"), 160)
+        if not topic:
+            return None, "keyword_watch requires a topic"
+        params["topic"] = topic
+    elif rtype == "research_question":
+        question = _alert_clip(params_in.get("question"), 240)
+        if not question:
+            return None, "research_question requires a question"
+        params["question"] = question
+
+    channels = []
+    for ch in (raw.get("channels") or ["chat", "voice"]):
+        c = _alert_clip(ch, 12)
+        if c in _ALERT_CHANNELS and c not in channels:
+            channels.append(c)
+    if not channels:
+        channels = ["chat"]
+
+    try:
+        cooldown = int(raw.get("cooldown_min", 1440))
+    except (TypeError, ValueError):
+        cooldown = 1440
+    cooldown = max(60, min(cooldown, 20160))  # 1 hour to 14 days
+
+    rule = {
+        "id": rid,
+        "label": label,
+        "type": rtype,
+        "params": params,
+        "cooldown_min": cooldown,
+        "channels": channels,
+        "enabled": bool(raw.get("enabled", True)),
+        "last_fired_iso": (existing or {}).get("last_fired_iso", ""),
+        "last_hash": (existing or {}).get("last_hash", ""),
+    }
+    return rule, ""
+
+
+def _sanitize_alert_settings(raw):
+    settings = dict(_DEFAULT_ALERT_SETTINGS)
+    if not isinstance(raw, dict):
+        return settings
+    for key in ("quiet_hours_start", "quiet_hours_end"):
+        try:
+            val = int(raw.get(key, -1))
+        except (TypeError, ValueError):
+            val = -1
+        settings[key] = val if -1 <= val <= 23 else -1
+    try:
+        settings["max_per_hour"] = max(1, min(int(raw.get("max_per_hour", 4)), 60))
+    except (TypeError, ValueError):
+        settings["max_per_hour"] = 4
+    try:
+        sal = float(raw.get("min_salience", 0.0))
+    except (TypeError, ValueError):
+        sal = 0.0
+    settings["min_salience"] = max(0.0, min(sal, 1.0))
+    return settings
+
+
+def _alert_cooldown_elapsed(rule, now):
+    """True if the rule has never fired or its cooldown window has passed."""
+    last = rule.get("last_fired_iso", "")
+    if not last:
+        return True
+    try:
+        last_dt = datetime.datetime.fromisoformat(last.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return True
+    if last_dt.tzinfo is None:
+        last_dt = last_dt.replace(tzinfo=datetime.timezone.utc)
+    elapsed_min = (now - last_dt).total_seconds() / 60.0
+    return elapsed_min >= rule.get("cooldown_min", 1440)
+
+
+def _alert_build_prompt(rule):
+    """Compose the background agent prompt for a rule. The agent must answer with
+    a leading ALERT: or QUIET: token so the tick can decide whether to surface."""
+    rtype = rule.get("type")
+    params = rule.get("params", {})
+    head = ("Background watch task (no user is present). Reply with plain text only. "
+            "Begin your reply with 'ALERT:' if there is something genuinely new and "
+            "noteworthy to report right now, otherwise begin with 'QUIET:'. ")
+    if rtype == "sec_filing":
+        syms = ", ".join(params.get("symbols", []))
+        return head + (
+            f"Check the most recent SEC EDGAR filings for these companies by ticker: {syms}. "
+            "Consider only filings from the last 7 days. If you find one, ALERT with the form "
+            "type, date, and a one-line description for each. If none, reply QUIET.")
+    if rtype == "weather":
+        return head + (
+            f"Check the weather forecast for {params.get('location', '')} for the next 24 to 48 hours. "
+            f"ALERT only if any of these are expected: {params.get('condition', '')}. "
+            "If ALERT, give one or two short lines with timing. Otherwise QUIET.")
+    if rtype == "space_weather":
+        return head + (
+            "Report current space weather using NOAA SWPC: the latest planetary Kp index and any active "
+            f"geomagnetic storm, solar flare, or radiation alerts. ALERT only if at or above {params.get('threshold', 'moderate')}. "
+            "If ALERT, give one or two short lines. Otherwise QUIET.")
+    if rtype == "keyword_watch":
+        return head + (
+            f"Search the web for genuinely new developments about: {params.get('topic', '')}. "
+            "Consider only items from roughly the last day or two. If you find something notable, ALERT with a "
+            "one to three sentence summary including the key fact and source name. Otherwise QUIET.")
+    if rtype == "research_question":
+        return head + (
+            f"Investigate and determine the current answer to this standing question: {params.get('question', '')}. "
+            "ALERT only if the answer has a notable update or newly significant development. If ALERT, give the "
+            "answer in one to three sentences. Otherwise QUIET.")
+    return None
+
+
+def _alert_salience(rule, body):
+    """Heuristic 0..1 importance score used by restraint gating."""
+    base = {
+        "sec_filing": 0.7,
+        "weather": 0.65,
+        "space_weather": 0.7,
+        "keyword_watch": 0.55,
+        "research_question": 0.6,
+    }.get(rule.get("type"), 0.5)
+    low = (body or "").lower()
+    if re.search(r"\b(severe|urgent|critical|warning|emergency|immediately|major)\b", low):
+        base = min(1.0, base + 0.2)
+    return round(base, 2)
+
+
+def _notify_count_last_hour(now):
+    cutoff = now - datetime.timedelta(hours=1)
+    n = 0
+    for rec in _notify_ring:
+        try:
+            ts = datetime.datetime.fromisoformat(str(rec.get("ts", "")).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=datetime.timezone.utc)
+        if ts >= cutoff:
+            n += 1
+    return n
+
+
+def _notify_in_quiet_hours(settings, now):
+    start = settings.get("quiet_hours_start", -1)
+    end = settings.get("quiet_hours_end", -1)
+    if start < 0 or end < 0 or start == end:
+        return False
+    hour = now.astimezone().hour
+    if start < end:
+        return start <= hour < end
+    # window wraps past midnight, e.g. 22 -> 7
+    return hour >= start or hour < end
+
+
+def _notify_enqueue(title, body, source, salience, channels, settings=None):
+    """Apply restraint, then append a notification to the ring + JSONL. Returns
+    the stored record, or None when suppressed. Never raises."""
+    try:
+        if settings is None:
+            settings = _load_alerts().get("settings", dict(_DEFAULT_ALERT_SETTINGS))
+        now = _utc_now()
+        critical = salience >= _NOTIFY_CRITICAL_SALIENCE
+        if salience < settings.get("min_salience", 0.0):
+            _telemetry_emit("notify", result="suppressed", reason="below_min_salience", source=source, salience=salience)
+            return None
+        if not critical and _notify_in_quiet_hours(settings, now):
+            _telemetry_emit("notify", result="suppressed", reason="quiet_hours", source=source, salience=salience)
+            return None
+        with _notify_lock:
+            if not critical and _notify_count_last_hour(now) >= settings.get("max_per_hour", 4):
+                _telemetry_emit("notify", result="suppressed", reason="rate_cap", source=source, salience=salience)
+                return None
+            record = {
+                "id": "ntf-" + uuid.uuid4().hex[:10],
+                "ts": _to_utc_iso(now),
+                "title": _alert_clip(title, 120) or "Eva",
+                "body": _alert_clip(body, 1200),
+                "source": _alert_clip(source, 64),
+                "salience": salience,
+                "channels": [c for c in (channels or ["chat"]) if c in _ALERT_CHANNELS] or ["chat"],
+                "seen": False,
+            }
+            _notify_ring.append(record)
+            if len(_notify_ring) > _NOTIFY_RING_MAX:
+                del _notify_ring[:-_NOTIFY_RING_MAX]
+            try:
+                os.makedirs(os.path.dirname(_NOTIFY_PATH), exist_ok=True)
+                if os.path.isfile(_NOTIFY_PATH) and os.path.getsize(_NOTIFY_PATH) >= _NOTIFY_MAX_BYTES:
+                    try:
+                        os.replace(_NOTIFY_PATH, _NOTIFY_PATH + ".1")
+                    except OSError:
+                        pass
+                with open(_NOTIFY_PATH, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(record) + "\n")
+            except OSError:
+                pass
+        _telemetry_emit("notify", result="emit", source=source, salience=salience,
+                        channels=",".join(record["channels"]))
+        print(f"[Notify] {record['title']} (salience {salience}, {source})")
+        return record
+    except Exception:
+        return None
+
+
+def _notify_mark_seen(ids):
+    """Mark ring notifications seen by id. Returns count updated."""
+    if not ids:
+        return 0
+    id_set = set(str(i) for i in ids)
+    updated = 0
+    with _notify_lock:
+        for rec in _notify_ring:
+            if rec.get("id") in id_set and not rec.get("seen"):
+                rec["seen"] = True
+                updated += 1
+    return updated
 
 
 class _MSALSilentCredential:
@@ -3261,6 +3603,79 @@ def _job_research_deepdive(ctx):
     }], "research deep-dive"
 
 
+def _job_alert_watch(ctx):
+    """Evaluate user-defined alert rules and surface notifications when they trip.
+    Each rule is checked through the background agent with a leading ALERT:/QUIET:
+    convention; firing is gated by per-rule cooldown and content-hash dedup."""
+    doc = _load_alerts()
+    rules = doc.get("alerts", [])
+    active = [r for r in rules if r.get("enabled")]
+    if not active:
+        return [], "no active alert rules"
+
+    now = _utc_now()
+    settings = doc.get("settings", dict(_DEFAULT_ALERT_SETTINGS))
+    proposals = []
+    fired = 0
+    checked = 0
+    notes = []
+    changed = False
+
+    for rule in active:
+        if not _alert_cooldown_elapsed(rule, now):
+            continue
+        # Re-check user presence before each (slow) agent call.
+        if ctx.get("trigger") != "manual" and time.time() - _last_user_activity_ts < 120:
+            notes.append("paused: user active")
+            break
+        prompt = _alert_build_prompt(rule)
+        if not prompt:
+            continue
+        checked += 1
+        text, error = _bg_agent_prompt(prompt, ctx, timeout=150)
+        if text is None:
+            notes.append(_alert_clip(rule.get("label"), 32) + ": " + error)
+            continue
+        if not text.strip().upper().startswith("ALERT"):
+            continue
+        body = text.strip()
+        content_hash = hashlib.sha1(body[:500].encode("utf-8")).hexdigest()
+        if content_hash == rule.get("last_hash"):
+            continue  # same finding as last fire; do not repeat
+        rule["last_fired_iso"] = ctx["now_iso"]
+        rule["last_hash"] = content_hash
+        changed = True
+        fired += 1
+        salience = _alert_salience(rule, body)
+        proposals.append({
+            "target_table": "Reflections",
+            "payload": {
+                "Timestamp": ctx["now_iso"],
+                "Trigger": "alert_watch:" + str(rule.get("id", "")),
+                "Observation": (f"Alert '{rule.get('label', '')}':\n" + body)[:1000],
+                "ActionTaken": "",
+                "Effectiveness": 0.0,
+            },
+            "auto_apply": True,
+            "notes": "alert " + _alert_clip(rule.get("label"), 40),
+            "notify": {
+                "title": _alert_clip(rule.get("label"), 80) or "Eva alert",
+                "body": body[:1200],
+                "source": "alert_watch:" + str(rule.get("id", "")),
+                "salience": salience,
+                "channels": rule.get("channels") or ["chat"],
+                "settings": settings,
+            },
+        })
+
+    if changed:
+        _save_alerts(doc)
+    if not proposals:
+        note = "; ".join(notes) if notes else (f"checked {checked}, none triggered" if checked else "no rules due")
+        return [], note
+    return proposals, f"{fired} alert(s) triggered"
+
+
 # Ordered registry of automation jobs run on each tick. Fast Kusto-only jobs
 # run first; the slower agent-prompt jobs (market, SEC, space weather, research)
 # run last so a single tick stays responsive and can bail if the user returns.
@@ -3277,6 +3692,7 @@ _BG_JOBS = [
     (_BG_JOB_SEC_FILINGS, _job_sec_filing_watch),
     (_BG_JOB_SPACE_WEATHER, _job_space_weather_alert),
     (_BG_JOB_RESEARCH_DEEPDIVE, _job_research_deepdive),
+    (_BG_JOB_ALERT_WATCH, _job_alert_watch),
 ]
 
 
@@ -3349,6 +3765,18 @@ def _run_background_tick(trigger="scheduled"):
                 if apply_ok:
                     applied += 1
                     row = _create_background_proposal_row(job_type, target_table, payload, window_start, window_end, notes + "; auto-applied (" + apply_note + ")", status="applied")
+                    # Surface findings the job flagged for the user (alert rules,
+                    # proactive briefings). Restraint + dedup live in _notify_enqueue.
+                    notify = proposal.get("notify")
+                    if isinstance(notify, dict):
+                        _notify_enqueue(
+                            notify.get("title", ""),
+                            notify.get("body", ""),
+                            notify.get("source", job_type),
+                            float(notify.get("salience", 0.5) or 0.5),
+                            notify.get("channels") or ["chat"],
+                            settings=notify.get("settings"),
+                        )
                 else:
                     failed_apply += 1
                     row = _create_background_proposal_row(job_type, target_table, payload, window_start, window_end, notes + "; auto-apply failed: " + apply_error, status="failed")
@@ -3631,6 +4059,10 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._background_proposals()
         elif parsed_path == "/v1/background/activity":
             self._background_activity()
+        elif parsed_path == "/v1/alerts":
+            self._alerts_list()
+        elif parsed_path == "/v1/notifications":
+            self._notifications_list()
         elif parsed_path == "/v1/memory/context":
             self._memory_context()
         elif parsed_path == "/v1/browser/status":
@@ -3667,6 +4099,12 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._goals_create()
         elif parsed_path == "/v1/background/control":
             self._background_control()
+        elif parsed_path == "/v1/alerts":
+            self._alerts_upsert()
+        elif parsed_path == "/v1/alerts/settings":
+            self._alerts_settings_update()
+        elif parsed_path == "/v1/notifications/seen":
+            self._notifications_mark_seen()
         elif re.fullmatch(r"/v1/background/proposals/[^/]+/(approve|reject)", parsed_path):
             self._background_review(parsed_path)
         elif parsed_path == "/v1/files/purge":
@@ -3685,6 +4123,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
         parsed_path = urllib.parse.urlparse(self.path).path
         if parsed_path.startswith("/v1/goals/"):
             self._goals_delete(urllib.parse.unquote(parsed_path.split("/v1/goals/", 1)[1]))
+        elif parsed_path.startswith("/v1/alerts/"):
+            self._alerts_delete(urllib.parse.unquote(parsed_path.split("/v1/alerts/", 1)[1]))
         else:
             self.send_error(404, "Not Found")
 
@@ -4309,6 +4749,99 @@ class BridgeHandler(BaseHTTPRequestHandler):
                 fields[k] = v if isinstance(v, bool) else _telemetry_clip(v, 60)
         _telemetry_emit("cognition_turn", source="frontend", **fields)
         self._json_response(200, {"status": "ok"})
+
+    def _notifications_list(self):
+        """Return recent proactive notifications for the front end to surface.
+        Query params: ?unseen_only=1, ?since=<id>, ?limit=N (default 20, max 100)."""
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        unseen_only = params.get("unseen_only", ["0"])[0] in ("1", "true", "yes")
+        since = (params.get("since", [""])[0] or "").strip()
+        try:
+            limit = int(params.get("limit", ["20"])[0])
+        except ValueError:
+            limit = 20
+        limit = max(1, min(limit, _NOTIFY_RING_MAX))
+        with _notify_lock:
+            items = list(_notify_ring)
+        if since:
+            idx = next((i for i, r in enumerate(items) if r.get("id") == since), None)
+            if idx is not None:
+                items = items[idx + 1:]
+        if unseen_only:
+            items = [r for r in items if not r.get("seen")]
+        items = items[-limit:]
+        self._json_response(200, {"notifications": items, "count": len(items)})
+
+    def _notifications_mark_seen(self):
+        data, error = self._read_json_body()
+        if error:
+            self._json_response(400, {"error": {"message": error}})
+            return
+        ids = data.get("ids") if isinstance(data, dict) else None
+        if not isinstance(ids, list):
+            self._json_response(400, {"error": {"message": "ids must be a list"}})
+            return
+        updated = _notify_mark_seen(ids)
+        self._json_response(200, {"status": "ok", "updated": updated})
+
+    def _alerts_list(self):
+        doc = _load_alerts()
+        self._json_response(200, {"alerts": doc.get("alerts", []), "settings": doc.get("settings", {}),
+                                  "types": list(_ALERT_TYPES), "channels": list(_ALERT_CHANNELS)})
+
+    def _alerts_upsert(self):
+        data, error = self._read_json_body()
+        if error:
+            self._json_response(400, {"error": {"message": error}})
+            return
+        with _alerts_lock:
+            doc = _load_alerts()
+            existing = None
+            rid_in = _alert_clip(data.get("id"), 64) if isinstance(data, dict) else ""
+            if rid_in:
+                existing = next((r for r in doc["alerts"] if r.get("id") == rid_in), None)
+            rule, rule_error = _sanitize_alert_rule(data, existing)
+            if rule_error:
+                self._json_response(400, {"error": {"message": rule_error}})
+                return
+            replaced = False
+            for i, r in enumerate(doc["alerts"]):
+                if r.get("id") == rule["id"]:
+                    doc["alerts"][i] = rule
+                    replaced = True
+                    break
+            if not replaced:
+                if len(doc["alerts"]) >= 50:
+                    self._json_response(400, {"error": {"message": "alert limit reached (50)"}})
+                    return
+                doc["alerts"].append(rule)
+            _save_alerts(doc)
+        self._json_response(200, {"status": "ok", "alert": rule})
+
+    def _alerts_delete(self, rule_id):
+        rule_id = str(rule_id or "").strip()
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", rule_id):
+            self._json_response(400, {"error": {"message": "alert id is invalid"}})
+            return
+        with _alerts_lock:
+            doc = _load_alerts()
+            before = len(doc["alerts"])
+            doc["alerts"] = [r for r in doc["alerts"] if r.get("id") != rule_id]
+            removed = before - len(doc["alerts"])
+            if removed:
+                _save_alerts(doc)
+        self._json_response(200, {"status": "ok", "removed": removed})
+
+    def _alerts_settings_update(self):
+        data, error = self._read_json_body()
+        if error:
+            self._json_response(400, {"error": {"message": error}})
+            return
+        with _alerts_lock:
+            doc = _load_alerts()
+            doc["settings"] = _sanitize_alert_settings(data)
+            _save_alerts(doc)
+        self._json_response(200, {"status": "ok", "settings": doc["settings"]})
 
     def _mcp_status(self):
         """Return current MCP server configuration status."""

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -3607,6 +3607,10 @@ def _job_alert_watch(ctx):
     """Evaluate user-defined alert rules and surface notifications when they trip.
     Each rule is checked through the background agent with a leading ALERT:/QUIET:
     convention; firing is gated by per-rule cooldown and content-hash dedup."""
+    # Snapshot the rules for evaluation. The slow agent calls below must NOT hold
+    # _alerts_lock, so per-rule bookkeeping (last_fired_iso/last_hash) is collected
+    # here and merged back under the lock at the end against a fresh read, which
+    # preserves any concurrent edits an API request made during the tick.
     doc = _load_alerts()
     rules = doc.get("alerts", [])
     active = [r for r in rules if r.get("enabled")]
@@ -3619,7 +3623,7 @@ def _job_alert_watch(ctx):
     fired = 0
     checked = 0
     notes = []
-    changed = False
+    pending_updates = {}  # rule_id -> {"last_fired_iso", "last_hash"}
 
     for rule in active:
         if not _alert_cooldown_elapsed(rule, now):
@@ -3642,9 +3646,10 @@ def _job_alert_watch(ctx):
         content_hash = hashlib.sha1(body[:500].encode("utf-8")).hexdigest()
         if content_hash == rule.get("last_hash"):
             continue  # same finding as last fire; do not repeat
-        rule["last_fired_iso"] = ctx["now_iso"]
-        rule["last_hash"] = content_hash
-        changed = True
+        pending_updates[str(rule.get("id", ""))] = {
+            "last_fired_iso": ctx["now_iso"],
+            "last_hash": content_hash,
+        }
         fired += 1
         salience = _alert_salience(rule, body)
         proposals.append({
@@ -3668,8 +3673,17 @@ def _job_alert_watch(ctx):
             },
         })
 
-    if changed:
-        _save_alerts(doc)
+    if pending_updates:
+        # Merge the fired-rule bookkeeping back under the lock against a fresh
+        # read so a concurrent API edit during the tick is not clobbered.
+        with _alerts_lock:
+            fresh = _load_alerts()
+            for r in fresh.get("alerts", []):
+                upd = pending_updates.get(str(r.get("id", "")))
+                if upd:
+                    r["last_fired_iso"] = upd["last_fired_iso"]
+                    r["last_hash"] = upd["last_hash"]
+            _save_alerts(fresh)
     if not proposals:
         note = "; ".join(notes) if notes else (f"checked {checked}, none triggered" if checked else "no rules due")
         return [], note
@@ -3769,11 +3783,17 @@ def _run_background_tick(trigger="scheduled"):
                     # proactive briefings). Restraint + dedup live in _notify_enqueue.
                     notify = proposal.get("notify")
                     if isinstance(notify, dict):
+                        # Coerce salience without treating a legitimate 0.0 as
+                        # missing (a plain `or 0.5` would mask zero-salience).
+                        try:
+                            _salience = float(notify.get("salience", 0.5))
+                        except (TypeError, ValueError):
+                            _salience = 0.5
                         _notify_enqueue(
                             notify.get("title", ""),
                             notify.get("body", ""),
                             notify.get("source", job_type),
-                            float(notify.get("salience", 0.5) or 0.5),
+                            _salience,
                             notify.get("channels") or ["chat"],
                             settings=notify.get("settings"),
                         )


### PR DESCRIPTION
## Summary

Two feature areas land together.

### Proactive alerts and notifications
Eva can watch user-defined alerts and surface findings on her own.

- New alerts store (`alerts.json`) with rule types: topic/keyword watch, standing research question, SEC filings, weather, space weather. Each has a label, cooldown, and delivery channels (chat, voice).
- New `alert_watch` background job folds into the existing 2h loop, evaluates due rules through the agent with an `ALERT`/`QUIET` convention, and dedups by content hash.
- Privacy-safe notification queue (in-memory ring + `notifications.jsonl`) the front end polls. New notifications appear as a tagged Eva chat bubble and are spoken when the rule asks.
- Restraint controls: quiet hours, per-hour cap, salience floor. High-salience alerts override the limits.
- Endpoints: `GET/POST /v1/alerts`, `POST /v1/alerts/settings`, `DELETE /v1/alerts/<id>`, `GET /v1/notifications`, `POST /v1/notifications/seen`.
- Logs record only labels, counts, and timestamps. Never message text or secrets.

### Voice view improvements
- Speaking phase now starts on actual audio playback rather than text arrival, fixing a race where the orb turned green with no sound and reverted to listening just before audio began.
- Long cognition turns no longer break the visualization: a re-arming watchdog holds the thinking phase until text or audio arrives.
- Conversation mode: after the wake word, Eva stays active so follow-ups need no repeat of her name, dropping to standby after a quiet period. On by default (30s), controls hidden but persisted.
- Barge-in: talk over Eva to interrupt and redirect. Mic echo cancellation plus a speaking-phase energy monitor stop TTS and open a conversation window.
- Organic orb waveform with traveling ripples so the whole ring stays alive, plus electrical impulse effects (radial discharges, orbiting sparks) scaled by phase and audio level.
- Outer rings darkened and made more transparent.

## Validation
- `python3 -c "import ast"` parse OK; `get_errors` clean across changed files.
- Offline helper tests for alert rule validation, persistence, cooldown, dedup, restraint (min-salience, rate cap, critical override), and mark-seen all pass.
- `tools/test_static.py`: 234/234.
- `node --check` clean on changed JS.
- Standalone AppImage 5.2.2 rebuilt.

## Notes
- Barge-in quality depends on OS/mic echo cancellation; headphones give the cleanest result. `THRESH`/`NEED_MS` in the barge monitor are the tuning knobs.
- Notification "seen" state is in-memory; records persist to JSONL but the seen flag resets on restart. A history panel and persisted seen-set are natural follow-ups.
