### PR TITLE
Cut conversation latency: fast-path gate, leaner reviewer, model swap (v5.2.3)

### DIFF
--- a/README-2.md
+++ b/README-2.md
@@ -452,7 +452,7 @@ A bundled desktop build that ships the web UI and the ACP bridge together. The E
 cd standalone
 npm install
 npm run dist
-./dist/'Eva Standalone-5.2.2.AppImage'
+./dist/'Eva Standalone-5.2.3.AppImage'
 ```
 
 Host prerequisites: Node.js 24+, Python 3.12+, Copilot CLI authenticated. The AppImage hides Bark and the AWS Polly engines from the Settings panel and locks the Kusto database to the value configured in first-run setup. Build details and runtime notes are in [standalone/README.md](standalone/README.md).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download or build the standalone Linux AppImage and run it. The bridge starts au
 cd standalone
 npm install
 npm run dist
-./dist/'Eva Standalone-5.2.2.AppImage'
+./dist/'Eva Standalone-5.2.3.AppImage'
 ```
 
 Prereqs on the host: Node.js 24+, Python 3.12+, GitHub Copilot CLI authenticated (`copilot auth login`). See [standalone/README.md](standalone/README.md).

--- a/core/js/cognition.js
+++ b/core/js/cognition.js
@@ -50,13 +50,17 @@
     reviewer: [
       "You are Eva's Reviewer agent inside Eva's runtime cognitive layer.",
       "You critique Eva's draft against the user's actual request.",
-      "Check for: factual accuracy, completeness, tone match, missed parts of the question,",
-      "unsafe suggestions, leaked internal pipeline mentions, hallucinated phase narration,",
-      "and whether any required action block ([[EVA_ACTION]]...[[/EVA_ACTION]]) is present",
-      "and well-formed when the user asked for a downloadable artifact.",
+      "Approve by default. Only request changes for MATERIAL problems: a factual",
+      "or numeric error, an unsafe suggestion, a missed or misread part of the",
+      "question, a leaked internal pipeline mention, hallucinated phase narration,",
+      "or a missing/malformed required action block ([[EVA_ACTION]]...[[/EVA_ACTION]])",
+      "when the user asked for a downloadable artifact.",
+      "Do NOT request changes for style, tone, length, phrasing, or minor polish you",
+      "merely prefer. If the draft is accurate, safe, and answers the question, APPROVE it.",
       "Always respond with a verdict line first:",
       "VERDICT: APPROVE  or  VERDICT: REQUEST_CHANGES",
-      "If requesting changes, follow with concrete bullets. Do not rewrite the answer."
+      "If requesting changes, follow with concrete bullets naming the specific defect.",
+      "Do not rewrite the answer."
     ].join(' ')
   };
 
@@ -100,7 +104,7 @@
 
   function getDefaultModel() {
     var el = document.getElementById('selAIGBackend');
-    return (el && el.value) ? el.value : 'claude-opus-4.8';
+    return (el && el.value) ? el.value : 'claude-sonnet-4.6';
   }
 
   function getCfg() {
@@ -108,7 +112,7 @@
     return {
       enabled: ls('cogEnabled', '1') === '1',
       evaModel:      ls('cogEvaModel', '')      || def,
-      reviewerModel: ls('cogReviewerModel', '') || 'gpt-5.5',
+      reviewerModel: ls('cogReviewerModel', '') || 'claude-opus-4.8',
       maxCycles: Math.max(0, parseInt(ls('cogMaxCycles', '1'), 10) || 0),
       evaPrompt:      ls('cogEvaPrompt', '')      || DEFAULT_PROMPTS.eva,
       reviewerPrompt: ls('cogReviewerPrompt', '') || DEFAULT_PROMPTS.reviewer,
@@ -406,14 +410,22 @@
   }
 
   // Deterministic review floor: turns where a second opinion is mandatory and
-  // Eva cannot opt out. Covers irreversible actions and high-fabrication-risk
-  // factual turns (markets, news, weather, briefings).
+  // Eva cannot opt out. Two intentionally small, legible buckets keep this easy
+  // to maintain. Edit a bucket here rather than scattering keywords.
+  //
+  //   FACTUAL_TOPICS   - subjects with real fabrication/staleness risk.
+  //   RETRIEVAL_INTENT - phrases that signal the user wants current/looked-up
+  //                      info. Kept tight (no bare "find"/"today"/"events")
+  //                      to avoid false positives on ordinary conversation.
+  var FACTUAL_TOPICS = /\b(brief(ing)?|brief me|news|headlines?|stocks?|prices?|quote|markets?|nasdaq|dow|s&p|weather|forecast|filings?|earnings|ticker|economy|economic)\b/i;
+  var RETRIEVAL_INTENT = /\b(look(ing)?\s*(it\s*)?up|search(\s+for)?|google|find\s+out|latest|most\s+recent|breaking|what'?s\s+(happening|going\s+on|new)|right\s+now)\b/i;
+
   function reviewFloorReason(userMsg, draftContent) {
     if (/\[\[EVA_ACTION\]\]|\[\[EVA_BROWSER\]\]|\[\[EVA_FILE\]\]/i.test(String(draftContent || ''))) {
       return 'action';
     }
-    var u = String(userMsg || '').toLowerCase();
-    if (/\b(brief(ing)?|brief me|news|headlines?|stocks?|prices?|quote|markets?|nasdaq|dow|s&p|weather|forecast|filings?|earnings|ticker)\b/.test(u)) {
+    var u = String(userMsg || '');
+    if (FACTUAL_TOPICS.test(u) || RETRIEVAL_INTENT.test(u)) {
       return 'factual';
     }
     return '';
@@ -484,23 +496,26 @@
     var lastVerdict = 'APPROVE';
 
     // Review gate: a deterministic floor forces review on irreversible or
-    // fact-bearing turns; above the floor, Eva decides via her sentinel. A
-    // missing signal defaults to review (safe). maxCycles=0 disables review.
+    // fact-bearing turns; above the floor, Eva can opt in via her sentinel.
+    // Everything else takes the fast path and skips review+revise. (We used to
+    // default a missing signal to "review anyway", but telemetry showed the
+    // sentinel is effectively never emitted, so every basic chat turn paid the
+    // full draft+review+revise cost. The floor still guarantees review on the
+    // high-fabrication-risk and irreversible categories.)
     var floorReason = reviewFloorReason(userMsg, current);
     var reviewReason;
     if (floorReason) {
       reviewReason = 'floor:' + floorReason;
     } else if (sentinel.want === true) {
       reviewReason = 'eva-opt-in';
-    } else if (sentinel.want === false) {
-      reviewReason = '';
     } else {
-      reviewReason = 'no-signal';
+      reviewReason = '';
     }
     var doReview = cfg.maxCycles >= 1 && !!reviewReason;
     if (!doReview) {
-      status('Eva answering directly [no review: ' +
-             (floorReason ? floorReason : (sentinel.want === false ? 'eva-opt-out' : 'disabled')) + ']...');
+      var skipWhy = cfg.maxCycles < 1 ? 'disabled'
+                  : (sentinel.want === false ? 'eva-opt-out' : 'fast-path');
+      status('Eva answering directly [no review: ' + skipWhy + ']...');
     }
 
     // Stage 2+: reviewer loop, bounded by cfg.maxCycles, gated by doReview
@@ -517,7 +532,11 @@
         'Review the draft. First line MUST be either:',
         'VERDICT: APPROVE',
         'VERDICT: REQUEST_CHANGES',
-        'If requesting changes, follow with concrete bullet points.'
+        'Approve by default. Only REQUEST_CHANGES for a material accuracy, safety,',
+        'or completeness defect (a wrong fact/number, an unsafe suggestion, or a',
+        'missed part of the question). Do not request changes for style, tone,',
+        'length, or wording you merely prefer.',
+        'If requesting changes, follow with concrete bullet points naming each defect.'
       ].join('\n');
       var _revStart = Date.now();
       var review = await callAgent(
@@ -579,7 +598,7 @@
       final_chars: (current || '').length,
       eva_model: draft.model || cfg.evaModel,
       reviewer_model: doReview ? cfg.reviewerModel : '',
-      review_reason: reviewReason || (sentinel.want === false ? 'eva-opt-out' : 'none'),
+      review_reason: reviewReason || (sentinel.want === false ? 'eva-opt-out' : 'fast-path'),
       last_verdict: doReview ? lastVerdict : 'n/a',
       sentinel_want: (sentinel.want === null ? 'absent' : String(sentinel.want))
     };
@@ -593,7 +612,7 @@
       cycles: cyclesUsed,
       lastVerdict: lastVerdict,
       reviewed: doReview,
-      reviewReason: reviewReason || (sentinel.want === false ? 'eva-opt-out' : 'none'),
+      reviewReason: reviewReason || (sentinel.want === false ? 'eva-opt-out' : 'fast-path'),
       telemetry: telem,
       forced: !!opts.forceEnable,
       forcedReason: opts.forcedReason || null

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
         <hr style="margin:14px 0;border:none;border-top:1px solid rgba(127,127,127,0.25)">
         <div class="auth-note" style="margin:0">
           <strong>About</strong><br>
-          Eva AI Assistant <span id="evaAppVersion">v5.2.2</span><br>
+          Eva AI Assistant <span id="evaAppVersion">v5.2.3</span><br>
           <span>Active goals: <span id="evaActiveGoalsCount">0</span></span><br>
           <span id="evaStandaloneVersion" style="display:none"></span>
         </div>
@@ -284,11 +284,11 @@
             <label for="selAIGBackend">Eva Backend Model:</label>
             <select id="selAIGBackend">
               <optgroup label="Claude (via ACP)">
-                <option value="claude-opus-4.8" selected>Claude Opus 4.8 (Default)</option>
+                <option value="claude-opus-4.8">Claude Opus 4.8</option>
                 <option value="claude-opus-4.6">Claude Opus 4.6</option>
                 <option value="claude-opus-4.6-1m">Claude Opus 4.6 (1M context)</option>
                 <option value="claude-opus-4.5">Claude Opus 4.5</option>
-                <option value="claude-sonnet-4.6">Claude Sonnet 4.6</option>
+                <option value="claude-sonnet-4.6" selected>Claude Sonnet 4.6 (Default)</option>
                 <option value="claude-haiku-4.5">Claude Haiku 4.5</option>
               </optgroup>
               <optgroup label="GPT (via ACP)">

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -33,14 +33,14 @@ The AppImage build is configured in `package.json` but this scaffold does not in
 
 ```sh
 cd standalone/dist
-chmod +x "Eva Standalone-5.2.2.AppImage"
-"./Eva Standalone-5.2.2.AppImage"
+chmod +x "Eva Standalone-5.2.3.AppImage"
+"./Eva Standalone-5.2.3.AppImage"
 ```
 
 If the host is missing FUSE (common on minimal containers and some distros), launch with extraction instead:
 
 ```sh
-"./Eva Standalone-5.2.2.AppImage" --appimage-extract-and-run
+"./Eva Standalone-5.2.3.AppImage" --appimage-extract-and-run
 ```
 
 The AppImage is self-contained: it spawns the bundled ACP bridge on a random localhost port at startup. The host still needs Copilot CLI authenticated once via `copilot auth login`.

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eva-standalone",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eva-standalone",
-      "version": "5.2.2",
+      "version": "5.2.3",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.8.1",

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eva-standalone",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Localhost Electron shell for Eva AI Assistant.",
   "main": "main.js",
   "private": true,


### PR DESCRIPTION
## Summary

Live telemetry (29 cognition turns) showed basic conversation paying the full draft + review + revise cost (~43s avg, p95 ~90s) because the "Eva decides" self-review sentinel was never emitted, so every turn defaulted to review. Tools were not the bottleneck (the slow turns were pure model-generation time across three serial heavyweight calls).

### Changes

- **Fast-path review gate.** No-floor, non-opt-in turns now skip review+revise. The deterministic floor still forces review on fact-bearing and irreversible turns, and Eva can opt in via her sentinel. A typical chat turn goes from three model calls to one.
- **Leaner reviewer rubric.** Approve by default; request changes only for a material accuracy, safety, or completeness defect, not style/tone/length. Cuts the revise stage when review does run (it was firing on 83% of reviewed turns).
- **Model split.** Main chat and voice default to Claude Sonnet 4.6 (fast draft); the reviewer defaults to Claude Opus 4.8 (strong fact-check). Defaults only; an explicit user choice still wins.
- **Floor broadened + refactored** into two named, commented buckets (`FACTUAL_TOPICS`, `RETRIEVAL_INTENT`) so lookup/search intent ("look up", "search", "latest", "what's happening") also triggers a review pass. Kept tight to avoid false positives on ordinary chat.
- **Telemetry** skip-path label is now `fast-path`.
- **Version → 5.2.3** (package manifests, UI badge, README references).

### Expected impact

Everyday chat: ~43s → a single Sonnet draft (~10-15s). Factual/lookup/action turns keep the full safety pipeline with Opus as the reviewer.

## Validation

- `node --check core/js/cognition.js` clean.
- Gate decision matrix verified (chat skips; weather/news/lookup/action review).
- Review floor matrix 11/11, including false-positive guards ("plan my birthday events", "find a good word" stay quiet).
- `tools/test_static.py`: 234/234.
- AppImage rebuilt as `Eva Standalone-5.2.3.AppImage`.

## Notes

- `used_acp_tools` in telemetry only tracks the bridge's own prefetch, not Copilot CLI's autonomous fetches, so it under-reports real lookups. Low priority; can be corrected separately.
