### PR TITLE
Voice mode: background log feed, softer barge-in, PDF auto-open

### DIFF
--- a/core/js/cognition.js
+++ b/core/js/cognition.js
@@ -364,10 +364,12 @@
 
   registerCapability({
     id: 'file.download',
-    description: 'Deliver a downloadable text artifact. ' +
-                 'args: {filename:string, content:string, mime?:string}. ' +
-                 'Artifact is virtually pathed at tmp/<session_id>/<filename> ' +
-                 'and rendered inline as a real download link.',
+    description: 'Deliver a downloadable artifact (text, markdown, csv, or a real PDF). ' +
+                 'args: {filename:string, content:string, mime?:string}. Use mime ' +
+                 '"application/pdf" or a .pdf filename to produce a genuine PDF. ' +
+                 'The artifact renders inline as Download/Open links and PDFs auto-open ' +
+                 'in a viewer tab. To let the user view it again, tell them to click the ' +
+                 'Open or Download link in your message; do NOT say you cannot open files.',
     run: async function (args) {
       args = args || {};
       var safeName = String(args.filename || 'eva-artifact.txt')
@@ -401,12 +403,22 @@
         return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
                         .replace(/"/g,'&quot;');
       };
+      // A PDF opens in a viewer; a plain text/markdown artifact opens as text.
+      // The link doubles as a download (download attr) and an opener.
+      var openHint = isPdf
+        ? ' <a href="' + href + '" target="_blank" rel="noopener" class="cog-dl-link">Open</a>'
+        : '';
       var html = '<div class="cog-action-file">' +
                  '<a href="' + href + '" download="' + esc(downloadName) +
-                 '" class="cog-dl-link">Download ' + esc(safeName) + '</a> ' +
+                 '" class="cog-dl-link">Download ' + esc(safeName) + '</a>' + openHint + ' ' +
                  '<span class="cog-dl-meta">(' + esc(mime) + ', ' + size +
                  ' bytes &middot; ' + esc(virtualPath) + ')</span>' +
                  '</div>';
+      // Auto-open PDFs so "open it" just works without a second click. Opened in
+      // a new tab/window; if the popup is blocked, the Open/Download links remain.
+      if (isPdf) {
+        try { window.open(href, '_blank', 'noopener'); } catch (_) {}
+      }
       return {
         html: html,
         filename: safeName,

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -1866,6 +1866,7 @@ function openVoiceView() {
   _vvStartCanvas();
   _vvStartWaveBar();
   _vvStartHUD();
+  _vvStartLogStream();
 }
 
 function closeVoiceView() {
@@ -1881,6 +1882,7 @@ function closeVoiceView() {
   if (_vv._watchTimer) { clearTimeout(_vv._watchTimer); _vv._watchTimer = null; }
   if (_vv._postTextTimer) { clearTimeout(_vv._postTextTimer); _vv._postTextTimer = null; }
   _vvStopBargeMonitor();
+  _vvStopLogStream();
   if (_vv._wasAutoSpeak !== undefined) {
     var autoSpeak = document.getElementById('autoSpeak');
     if (autoSpeak) autoSpeak.checked = _vv._wasAutoSpeak;
@@ -1940,6 +1942,56 @@ function _vvStartHUD() {
 
 function _vvStopHUD() {
   if (_vv.hudInterval) { clearInterval(_vv.hudInterval); _vv.hudInterval = null; }
+}
+
+// --- Background log feed (faint scrolling bridge stdout) ---
+
+function _vvStartLogStream() {
+  var el = document.getElementById('vvLogStream');
+  if (!el) return;
+  el.innerHTML = '';
+  _vv._logSince = 0;
+  _vv._logPolling = false;
+  _vvPollLogStream();
+  _vv.logInterval = setInterval(_vvPollLogStream, 1500);
+}
+
+function _vvStopLogStream() {
+  if (_vv.logInterval) { clearInterval(_vv.logInterval); _vv.logInterval = null; }
+  var el = document.getElementById('vvLogStream');
+  if (el) el.innerHTML = '';
+}
+
+async function _vvPollLogStream() {
+  if (!_vv.open || _vv._logPolling) return;
+  _vv._logPolling = true;
+  try {
+    var base = (typeof getSafeBridgeBaseUrl === 'function') ? getSafeBridgeBaseUrl() : '';
+    if (!base) return;
+    var opts = { method: 'GET' };
+    if (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) opts.signal = AbortSignal.timeout(2500);
+    var resp = await fetch(base.replace(/\/+$/, '') + '/v1/logs?since=' + (_vv._logSince || 0) + '&limit=40', opts);
+    if (!resp.ok) return;
+    var data = await resp.json();
+    var lines = (data && Array.isArray(data.lines)) ? data.lines : [];
+    if (typeof data.last === 'number') _vv._logSince = data.last;
+    if (!lines.length) return;
+    var el = document.getElementById('vvLogStream');
+    if (!el) return;
+    lines.forEach(function (ln) {
+      var div = document.createElement('div');
+      div.className = 'vv-log-line';
+      div.textContent = String(ln.text || '');
+      el.appendChild(div);
+    });
+    // Cap the rendered backlog so the DOM stays light.
+    while (el.childNodes.length > 60) el.removeChild(el.firstChild);
+    el.scrollTop = el.scrollHeight;
+  } catch (_) {
+    // Bridge unreachable or logs unavailable; stay quiet.
+  } finally {
+    _vv._logPolling = false;
+  }
 }
 
 function _vvUpdateHUD() {
@@ -2936,9 +2988,9 @@ function _vvStartBargeMonitor() {
   _vvStopBargeMonitor();
   if (!_vv.analyser || !_vv.dataArray) return;
   var aboveSince = 0;
-  var NEED_MS = 300;   // sustained user speech before interrupting
-  var THRESH = 40;     // min average mic energy (0-255) to consider speech
-  var graceUntil = performance.now() + 700;
+  var NEED_MS = 220;   // sustained user speech before interrupting
+  var THRESH = 22;     // min average mic energy (0-255) to consider speech
+  var graceUntil = performance.now() + 600;
   function loop() {
     if (_vv.phase !== 'speaking' || !_vv.open || !_vv.analyser) { _vv.bargeRAF = null; return; }
     _vv.analyser.getByteFrequencyData(_vv.dataArray);
@@ -2946,8 +2998,10 @@ function _vvStartBargeMonitor() {
     for (var i = 0; i < _vv.dataArray.length; i++) sum += _vv.dataArray[i];
     var micAvg = sum / _vv.dataArray.length;
 
-    // Current TTS playback level, so the bar to interrupt rises while Eva is
-    // loud and falls in her pauses (belt-and-suspenders alongside AEC).
+    // Current TTS playback level. With echo cancellation already removing Eva's
+    // own voice from the mic, this only needs to be a light guard against any
+    // residual echo, so the bar to interrupt stays low enough for a normal
+    // speaking voice picked up at a distance.
     var ttsAvg = 0;
     if (_vv.ttsAnalyser && _vv.ttsDataArray) {
       _vv.ttsAnalyser.getByteFrequencyData(_vv.ttsDataArray);
@@ -2957,7 +3011,7 @@ function _vvStartBargeMonitor() {
     }
 
     var now = performance.now();
-    var isUser = now > graceUntil && micAvg > THRESH && micAvg > (ttsAvg * 0.6 + 10);
+    var isUser = now > graceUntil && micAvg > THRESH && micAvg > (ttsAvg * 0.35 + 5);
     if (isUser) {
       if (!aboveSince) aboveSince = now;
       else if (now - aboveSince >= NEED_MS) { _vv.bargeRAF = null; _vvBargeIn(); return; }

--- a/core/themes/eva.css
+++ b/core/themes/eva.css
@@ -936,8 +936,37 @@ body.theme-eva .cog-badge[data-active="true"] {
   );
 }
 
-/* Close button */
-.voice-view-close {
+/* Faint background log feed: scrolling bridge stdout behind the orb */
+.vv-log-stream {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 40px 36px 90px;
+  font-family: "SF Mono", "Fira Code", "Courier New", monospace;
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: rgba(120,200,255,0.07);
+  white-space: nowrap;
+  /* Fade older lines out toward the top so it reads as ambient texture. */
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.5) 30%, #000 75%);
+  mask-image: linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.5) 30%, #000 75%);
+}
+.vv-log-line {
+  overflow: hidden;
+  text-overflow: clip;
+  animation: vvLogIn 0.6s ease-out;
+}
+@keyframes vvLogIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+body.theme-lcars .vv-log-stream { color: rgba(255,170,90,0.06); }
+
   position: absolute;
   top: 20px;
   right: 28px;

--- a/index.html
+++ b/index.html
@@ -891,6 +891,8 @@
   <!-- Voice View — ambient, always-listening mode -->
   <div id="voiceView" class="voice-view" aria-hidden="true">
     <button id="voiceViewClose" class="voice-view-close" type="button" aria-label="Exit voice view">&times;</button>
+    <!-- Faint background log feed (bridge stdout) -->
+    <div id="vvLogStream" class="vv-log-stream" aria-hidden="true"></div>
     <!-- Scanline overlay -->
     <div class="vv-scanline"></div>
     <!-- Top HUD bar -->

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -1153,6 +1153,70 @@ _telemetry_lock = threading.Lock()
 _telemetry_ring = []  # list of recent event dicts (most recent last)
 
 
+# ── Log ring — recent stdout lines, for the voice-mode background feed ───────
+# A tee on stdout mirrors every printed line both to the real terminal and to a
+# small in-memory ring. The voice view polls GET /v1/logs and renders these as
+# a faint scrolling console behind the orb. Lines are bridge status output
+# (already free of secrets by the project's logging discipline); each is length-
+# capped defensively.
+_LOG_RING_MAX = 200
+_LOG_LINE_CAP = 240
+_log_lock = threading.Lock()
+_log_ring = []   # list of (seq, text)
+_log_seq = 0
+
+
+class _StdoutTee:
+    """Wrap a stream so writes go to the original AND into the log ring.
+    Buffers partial writes until a newline so ring entries are whole lines."""
+
+    def __init__(self, original):
+        self._orig = original
+        self._buf = ""
+
+    def write(self, s):
+        try:
+            self._orig.write(s)
+        except Exception:
+            pass
+        try:
+            self._buf += s
+            while "\n" in self._buf:
+                line, self._buf = self._buf.split("\n", 1)
+                _log_ring_add(line)
+        except Exception:
+            pass
+
+    def flush(self):
+        try:
+            self._orig.flush()
+        except Exception:
+            pass
+
+    def __getattr__(self, name):
+        return getattr(self._orig, name)
+
+
+def _log_ring_add(line):
+    global _log_seq
+    line = (line or "").rstrip()
+    if not line:
+        return
+    if len(line) > _LOG_LINE_CAP:
+        line = line[:_LOG_LINE_CAP] + "…"
+    with _log_lock:
+        _log_seq += 1
+        _log_ring.append((_log_seq, line))
+        if len(_log_ring) > _LOG_RING_MAX:
+            del _log_ring[:-_LOG_RING_MAX]
+
+
+def _install_log_tee():
+    """Route stdout through the tee once (idempotent)."""
+    if not isinstance(sys.stdout, _StdoutTee):
+        sys.stdout = _StdoutTee(sys.stdout)
+
+
 def _telemetry_clip(value, limit=120):
     """Clip a label/string field so telemetry never stores large or sensitive blobs."""
     if value is None:
@@ -4419,6 +4483,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._mcp_persisted_config()
         elif parsed_path == "/v1/telemetry":
             self._telemetry_report()
+        elif parsed_path == "/v1/logs":
+            self._logs_view()
         elif parsed_path == "/v1/goals":
             self._goals_list()
         elif parsed_path == "/v1/skills":
@@ -5274,6 +5340,26 @@ class BridgeHandler(BaseHTTPRequestHandler):
             "summary": _telemetry_summarize(events),
             "events": recent,
         })
+
+    def _logs_view(self):
+        """Return recent stdout log lines for the voice-mode background feed.
+        Query params: ?since=<seq> (only lines newer than this), ?limit=N."""
+        from urllib.parse import urlparse, parse_qs
+        params = parse_qs(urlparse(self.path).query)
+        try:
+            since = int(params.get("since", ["0"])[0])
+        except ValueError:
+            since = 0
+        try:
+            limit = int(params.get("limit", ["60"])[0])
+        except ValueError:
+            limit = 60
+        limit = max(1, min(limit, _LOG_RING_MAX))
+        with _log_lock:
+            rows = [{"n": n, "text": t} for (n, t) in _log_ring if n > since]
+            last = _log_seq
+        rows = rows[-limit:]
+        self._json_response(200, {"lines": rows, "last": last})
 
     def _telemetry_ingest(self):
         """Accept a privacy-safe cognition timing record from the front end and
@@ -6459,6 +6545,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
 
 def main():
     global _bridge_bind_address
+    _install_log_tee()
     default_port = 8888
     env_port = os.environ.get("EVA_ACP_PORT", "").strip()
     if env_port:


### PR DESCRIPTION
## Summary

Three voice-mode fixes.

### Background log feed (new)
The bridge now tees its stdout into a small in-memory ring buffer (HTTP access logs stay on stderr, so the voice view's own polling can't create a feedback loop) and serves it at `GET /v1/logs?since=&limit=`. The voice view polls it every 1.5s and renders the lines as a very faint, monospace console scrolling up behind the orb, faded toward the top so it reads as ambient texture rather than something you read line by line. It shows the real bridge activity (`[Bridge]`, `[ACP]`, `[Cognition]`, `[Telemetry]`).

### Barge-in reliability
Interrupting Eva while she spoke was unreliable; the thresholds were too strict for a normal speaking voice picked up at mic distance. Since echo cancellation already removes Eva's own voice, the guard was over-tuned. Lowered:
- absolute mic threshold 40 → 22
- residual-echo guard `ttsAvg*0.6 + 10` → `ttsAvg*0.35 + 5`
- sustained-speech window 300 → 220 ms
- startup grace 700 → 600 ms

### PDF open
`file.download` now auto-opens a generated PDF in a viewer tab and renders both **Open** and **Download** links. Eva's capability wording was corrected so she points the user to those links instead of saying she cannot open files on their machine.

## Validation

- `node --check` clean on changed JS; `python3 ast` clean on the bridge.
- `tools/test_static.py`: 234/234.
- `tools/test_skills_e2e.py`: 14/14.
- New `/v1/logs` endpoint tested end-to-end over the real HTTP server (capture + incremental since-cursor).
- AppImage rebuilt.

## Notes

- Barge-in remains hardware-dependent; the new thresholds are a single-number tweak if a given mic/speaker setup needs more or less sensitivity.
- PDF auto-open covers the generate-then-view flow. Asking Eva to "open it" on a later turn still regenerates (the earlier blob URL is gone).
- The log feed lines are bridge status output, already free of secrets by the project's logging discipline, and each line is length-capped defensively.
