### PR TITLE
feat: doctor diagnostics, cron scheduler, auto-learn skills, subagent…

### DIFF
--- a/.github/workflows/pa11y_accessibility_testing.yml
+++ b/.github/workflows/pa11y_accessibility_testing.yml
@@ -21,4 +21,4 @@ jobs:
 
       - name: Run Pa11y on local site
         run: |
-          pa11y /home/runner/work/chatgpt-html/chatgpt-html/index.html --reporter=cli --threshold 25
+          pa11y /home/runner/work/eva-agent/eva-agent/index.html --reporter=cli --threshold 25

--- a/README.md
+++ b/README.md
@@ -2,42 +2,56 @@
 
 ![screenshot](core/img/Eva-splash.png)
 
-A no-build web UI for chatting with multiple AI providers, with persistent memory, emotion tracking, and multi-agent orchestration. Pure HTML, CSS, and JavaScript.
+[Website](https://appatalks.github.io/eva-agent/) | [Documentation](README-2.md) | [Issues](https://github.com/appatalks/eva-agent/issues) | License: MIT
 
-> Recommended: select **Eva (AIG)** in the model dropdown for the full experience.
+A voice-first AI assistant that sees through your camera, controls your browser and desktop, remembers everything, learns from experience, and runs tasks on a schedule. No build step. No framework. Open source.
 
-## Get Started
-
-Run the installer first. It detects and installs every dependency Eva needs on
-your machine (Linux or macOS), self-updates the checkout, and can rebuild the
-AppImage:
+## Quick install
 
 ```bash
-./install.sh            # check dependencies, install missing (asks first)
-./install.sh --check    # report only, install nothing
-./install.sh --yes      # install everything missing, no prompts
+curl -fsSL https://appatalks.github.io/eva-agent/get-eva.sh | bash
 ```
 
-Then download or build the standalone Linux AppImage and run it. The bridge
-starts automatically on a private localhost port.
+Or clone and run locally:
 
 ```bash
-cd standalone
-npm install
-npm run dist
+git clone https://github.com/appatalks/eva-agent.git
+cd eva-agent
+./install.sh            # install dependencies
+cd standalone && npm install && npm run dist
 ./dist/'Eva Standalone-5.2.3.AppImage'
 ```
 
-Prereqs on the host: Node.js 24+, Python 3.12+, GitHub Copilot CLI authenticated (`copilot auth login`). See [standalone/README.md](standalone/README.md).
+Prereqs: Node.js 24+, Python 3.12+, GitHub Copilot CLI (`copilot auth login`).
 
-> **Tip:** For the full Eva experience (persistent memory, emotion tracking, knowledge graph), point Settings > MCP at an Azure Data Explorer cluster you can sign in to. The bridge uses `azure-identity` device code or interactive login on first use, so no keys are stored. Browser-only setup and the manual ACP bridge launch are documented in [README-2.md](README-2.md).
->
-> **Semantic recall:** When an OpenAI API key is set in Settings > Auth, Eva ranks stored facts by meaning (OpenAI `text-embedding-3-small`, cached on disk) so relevant memories surface even when worded differently. Without a key, recall falls back to synonym-expanded keyword matching.
+## Features
 
-> **Skills:** Import a skill from pasted text, a URL, a GitHub repo/SKILL.md, or a file in Settings > Models > Skills. Eva normalizes ("Eva'rises") it into her own format, stores it in ADX, and applies the matching skill automatically when a request fits.
+| | |
+|---|---|
+| **Camera vision** | Webcam presence sensing, face-detection auto-wake, on-demand "look" with gpt-4o |
+| **Browser agent** | Playwright-based DOM control, persistent Chrome login, hybrid vision fallback |
+| **Desktop agent** | PyAutoGUI mouse/keyboard control, optional AT-SPI via computer-use-linux MCP |
+| **Voice interface** | Full-screen voice orb, wake/barge-in, TTS (OpenAI, Polly, Bark, browser) |
+| **Persistent memory** | Kusto/ADX-backed conversations, emotion tracking, semantic recall |
+| **Self-improving skills** | Auto-extracts reusable skills from successful tasks, stored as drafts |
+| **Cron scheduler** | Standard cron expressions, recurring prompts, morning briefings, alerts |
+| **Subagent parallelism** | Spawn up to 4 concurrent ACP tasks, results via notifications |
+| **Multi-provider** | OpenAI, Google Gemini, GitHub Copilot, lm-studio (local) |
+| **Doctor diagnostics** | Structured readiness probe for every subsystem with actionable fixes |
+| **MCP ecosystem** | Azure, GitHub, Kusto, computer-use-linux desktop control |
+| **Cognitive layer** | Eva + Reviewer dual-agent pipeline with configurable models |
+
+## Get started
+
+Select **Eva (AIG)** in the model dropdown for the full experience.
+
+For persistent memory, point Settings > MCP at an Azure Data Explorer cluster. The bridge uses `azure-identity` device code login, no keys stored. For semantic recall, add an OpenAI key in Settings > Auth (falls back to keyword matching without one).
+
+Import skills from text, URLs, GitHub repos, or files in Settings. Eva normalizes them into her format, stores in ADX, and applies matching skills automatically.
 
 ## Documentation
 
 - [README-2.md](README-2.md): architecture, MCP, ACP, browser-only setup, roadmap
 - [standalone/README.md](standalone/README.md): AppImage build and runtime
+- [Website](https://appatalks.github.io/eva-agent/): features, comparison, install guide
 

--- a/core/js/cognition.js
+++ b/core/js/cognition.js
@@ -62,6 +62,12 @@
       "front of the camera, emit one line [[EVA_LOOK]]{\"question\":\"<what to look for>\"}[[/EVA_LOOK]] (the",
       "question is optional). A frame is captured and you describe it. Do NOT claim you cannot see or use a",
       "camera. Emit at most one EVA_LOOK per reply, only when the user asks you to look or about what you see.",
+      "SCHEDULED TASKS: Eva has a cron scheduler. When the user asks to schedule something recurring",
+      "(daily briefings, periodic checks, reminders), acknowledge that this can be set up in Settings > Cron.",
+      "SUBAGENTS: For multi-part tasks that can run in parallel, Eva can spawn isolated subagents. Each runs",
+      "its own prompt concurrently and delivers results via notifications when done.",
+      "SKILLS: Eva learns from successful complex tasks. After finishing a browser or desktop task, she may",
+      "auto-extract a reusable skill. Skills are stored as drafts for user review in Settings > Goals/Skills.",
       "Do NOT narrate phases. Do NOT mention the pipeline, the reviewer,",
       "or any '.github/agents/' file. Do NOT print fake 'PHASE 1 / PHASE 2 / PHASE 3' headers.",
       "Just answer the user."

--- a/core/js/copilot.js
+++ b/core/js/copilot.js
@@ -416,6 +416,8 @@ function populateMCPForm(cfg) {
   if (kustoCheckL && kustoConfig) {
     kustoConfig.style.display = kustoCheckL.checked ? 'block' : 'none';
   }
+  var cuCheck = document.getElementById('mcpComputerUse');
+  if (cuCheck) cuCheck.checked = !!cfg['computer-use-linux'];
 }
 
 // Re-apply the saved MCP config to a freshly started bridge.
@@ -525,6 +527,15 @@ async function applyMCPConfig() {
       command: 'python3',
       args: ['tools/kusto_mcp.py'],
       env: kustoEnv
+    };
+  }
+
+  // Computer Use Linux MCP (AT-SPI desktop control)
+  var cuCheck = document.getElementById('mcpComputerUse');
+  if (cuCheck && cuCheck.checked) {
+    mcpServers['computer-use-linux'] = {
+      command: 'computer-use-linux',
+      args: ['mcp']
     };
   }
 

--- a/core/js/gpt-core.js
+++ b/core/js/gpt-core.js
@@ -228,7 +228,7 @@ async function trboSend() {
         }
 
         // Exclude messages with the "developer" role see 
-        // https://github.com/appatalks/chatgpt-html/issues/63#issuecomment-2492821202 
+        // https://github.com/appatalks/eva-agent/issues/63#issuecomment-2492821202 
         if (sModel === 'o1-preview' || sModel === 'o1-mini') {
           kMessages = kMessages.filter(msg => msg.role === 'user' || msg.role === 'assistant');
           dTemperature = 1;

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -693,6 +693,200 @@ function renderBackgroundAll() {
   renderBackgroundActivity();
 }
 
+// ---------------------------------------------------------------------------
+// Doctor diagnostics
+// ---------------------------------------------------------------------------
+async function runDoctor() {
+  var btn = document.getElementById('doctorButton');
+  var report = document.getElementById('doctorReport');
+  if (btn) btn.disabled = true;
+  if (report) { report.style.display = 'block'; report.textContent = 'Running diagnostics...'; }
+  try {
+    var bridgeUrl = await detectACPBridge();
+    var resp = await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/doctor');
+    var data = await resp.json();
+    if (!resp.ok) { if (report) report.textContent = 'Error: ' + (data.error ? data.error.message : 'unknown'); return; }
+
+    // Format the report
+    var lines = [];
+    var r = data.readiness || {};
+    var b = data.blockers || [];
+    lines.push('=== Eva Diagnostics ===');
+    lines.push('');
+    lines.push('Readiness:');
+    var checks = [
+      ['Chat (ACP)', r.can_chat],
+      ['Browser agent', r.can_browse],
+      ['Desktop agent', r.can_desktop],
+      ['Camera/vision', r.can_see],
+      ['Memory (Kusto)', r.can_remember],
+      ['Background loop', r.can_schedule],
+      ['Cron tasks', r.can_cron],
+    ];
+    for (var i = 0; i < checks.length; i++) {
+      lines.push('  ' + (checks[i][1] ? '\u2705' : '\u274c') + ' ' + checks[i][0]);
+    }
+
+    var ss = data.subsystems || {};
+    if (ss.system) {
+      lines.push('');
+      lines.push('System: Python ' + (ss.system.python || '?') + ', Node ' + (ss.system.node || 'not found'));
+      lines.push('Platform: ' + (ss.system.platform || '?') + ' (' + (ss.system.arch || '?') + ')');
+    }
+    if (ss.mcp) {
+      lines.push('MCP servers: ' + (ss.mcp.configured || []).join(', ') || 'none');
+    }
+    if (ss.desktop_agent) {
+      if (ss.desktop_agent.computer_use_linux_available) lines.push('computer-use-linux: installed');
+      if (ss.desktop_agent.ydotool_available) lines.push('ydotool: available');
+    }
+    if (b.length) {
+      lines.push('');
+      lines.push('Blockers:');
+      for (var j = 0; j < b.length; j++) lines.push('  - ' + b[j]);
+    }
+    if (report) report.textContent = lines.join('\n');
+  } catch (e) {
+    if (report) report.textContent = 'Failed: ' + e.message + ' \u2014 Is the bridge running?';
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cron scheduler UI
+// ---------------------------------------------------------------------------
+async function cronRefresh() {
+  var listEl = document.getElementById('cronList');
+  var statusEl = document.getElementById('cronStatus');
+  try {
+    var bridgeUrl = await detectACPBridge();
+    var resp = await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/cron');
+    var data = await resp.json();
+    if (!resp.ok) { if (statusEl) statusEl.textContent = 'Error: ' + (data.error ? data.error.message : 'unknown'); return; }
+    if (statusEl) statusEl.textContent = data.count + ' task(s)';
+    if (!listEl) return;
+    var tasks = data.tasks || [];
+    if (!tasks.length) { listEl.innerHTML = '<p class="auth-note">No cron tasks. Add one above.</p>'; return; }
+    var html = '';
+    for (var i = 0; i < tasks.length; i++) {
+      var t = tasks[i];
+      var enabled = t.enabled !== false;
+      html += '<div class="background-item" style="margin-bottom:10px;padding:8px;border:1px solid rgba(127,127,127,0.2);border-radius:6px">';
+      html += '<div style="display:flex;justify-content:space-between;align-items:center">';
+      html += '<strong>' + _escHtml(t.label) + '</strong>';
+      html += '<span style="font-size:11px;opacity:0.7">' + _escHtml(t.schedule) + '</span>';
+      html += '</div>';
+      html += '<p style="margin:4px 0;font-size:12px;opacity:0.8">' + _escHtml(t.prompt).substring(0, 200) + '</p>';
+      html += '<div style="font-size:11px;opacity:0.6">';
+      if (t.next_run) html += 'Next: ' + t.next_run.substring(0, 16).replace('T', ' ') + ' UTC';
+      if (t.last_run) html += ' | Last: ' + t.last_run.substring(0, 16).replace('T', ' ') + ' UTC';
+      html += '</div>';
+      html += '<div style="margin-top:6px;display:flex;gap:6px">';
+      html += '<button class="auth-toggle" style="font-size:11px;padding:2px 8px" onclick="cronToggle(\'' + t.id + '\',' + !enabled + ')">' + (enabled ? 'Disable' : 'Enable') + '</button>';
+      html += '<button class="auth-toggle" style="font-size:11px;padding:2px 8px;color:#c44" onclick="cronDelete(\'' + t.id + '\')">Delete</button>';
+      html += '</div></div>';
+    }
+    listEl.innerHTML = html;
+  } catch (e) {
+    if (statusEl) statusEl.textContent = 'Failed: ' + e.message;
+  }
+}
+
+async function cronAdd() {
+  var label = (document.getElementById('cronLabel') || {}).value || '';
+  var schedule = (document.getElementById('cronSchedule') || {}).value || '';
+  var prompt = (document.getElementById('cronPrompt') || {}).value || '';
+  var statusEl = document.getElementById('cronStatus');
+  if (!label.trim() || !schedule.trim() || !prompt.trim()) {
+    if (statusEl) statusEl.textContent = 'All three fields are required.';
+    return;
+  }
+  try {
+    var bridgeUrl = await detectACPBridge();
+    var resp = await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/cron', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: label.trim(), schedule: schedule.trim(), prompt: prompt.trim() })
+    });
+    var data = await resp.json();
+    if (!resp.ok) { if (statusEl) statusEl.textContent = 'Error: ' + (data.error ? data.error.message : 'unknown'); return; }
+    if (statusEl) statusEl.textContent = 'Created: ' + (data.task ? data.task.label : '');
+    // Clear form
+    if (document.getElementById('cronLabel')) document.getElementById('cronLabel').value = '';
+    if (document.getElementById('cronSchedule')) document.getElementById('cronSchedule').value = '';
+    if (document.getElementById('cronPrompt')) document.getElementById('cronPrompt').value = '';
+    cronRefresh();
+  } catch (e) {
+    if (statusEl) statusEl.textContent = 'Failed: ' + e.message;
+  }
+}
+
+async function cronToggle(taskId, enable) {
+  try {
+    var bridgeUrl = await detectACPBridge();
+    await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/cron/' + encodeURIComponent(taskId), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: enable })
+    });
+    cronRefresh();
+  } catch (e) { /* ignore */ }
+}
+
+async function cronDelete(taskId) {
+  try {
+    var bridgeUrl = await detectACPBridge();
+    await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/cron/' + encodeURIComponent(taskId), { method: 'DELETE' });
+    cronRefresh();
+  } catch (e) { /* ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// Skills auto-learn — extract skill from recent interaction
+// ---------------------------------------------------------------------------
+async function autoLearnSkill(messages, taskSummary) {
+  try {
+    var bridgeUrl = await detectACPBridge();
+    var resp = await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/skills/auto-learn', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: messages || [], task_summary: taskSummary || '' })
+    });
+    var data = await resp.json();
+    if (resp.ok && data.draft) {
+      // Auto-create the skill as a draft
+      var draft = data.draft;
+      var createResp = await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          Name: draft.Name || 'Auto-learned skill',
+          Description: draft.Description || '',
+          Instructions: draft.Instructions || '',
+          Tools: draft.Tools || '',
+          Tags: (draft.Tags || '') + (draft.Tags ? ',auto-learned' : 'auto-learned'),
+          Source: 'auto-learned',
+          Status: 'draft'
+        })
+      });
+      if (createResp.ok) {
+        setStatus('info', 'Skill learned: ' + (draft.Name || 'untitled'));
+      }
+      return data.draft;
+    }
+    return null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function _escHtml(s) {
+  var div = document.createElement('div');
+  div.appendChild(document.createTextNode(s || ''));
+  return div.innerHTML;
+}
+
 async function loadBackgroundData(quiet) {
   if (_backgroundState.loading) return;
   _backgroundState.loading = true;
@@ -893,6 +1087,15 @@ function _evaAgentFeedback(status, endpoint, title) {
   } catch (_) {}
 
   if (typeof lastResponse === 'string') lastResponse = spoken;
+
+  // 4) Auto-learn: when a complex task completes successfully, extract a reusable skill.
+  if (state === 'done' && goal && typeof autoLearnSkill === 'function') {
+    try {
+      var hist = JSON.parse(localStorage.getItem('aigMessages') || '[]');
+      var recent = Array.isArray(hist) ? hist.slice(-10) : [];
+      autoLearnSkill(recent, goal);
+    } catch (_) {}
+  }
 }
 
 // Render + speak the result of an Eva "look" (webcam vision). Mirrors the agent
@@ -2260,7 +2463,7 @@ function _vvStartLogStream() {
   _vv._logSince = 0;
   _vv._logPolling = false;
   _vvPollLogStream();
-  _vv.logInterval = setInterval(_vvPollLogStream, 1500);
+  _vv.logInterval = setInterval(_vvPollLogStream, 15000);
 }
 
 function _vvStopLogStream() {

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#12121e" stroke="#7c6aef" stroke-width="2"/>
+  <circle cx="16" cy="16" r="5" fill="#7c6aef">
+    <animate attributeName="opacity" values="1;0.5;1" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="16" cy="16" r="8" fill="none" stroke="#a78bfa" stroke-width="0.8" opacity="0.4"/>
+</svg>

--- a/docs/get-eva.sh
+++ b/docs/get-eva.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# ============================================================================
+#  Eva AI Assistant — remote installer
+#
+#  curl -fsSL https://appatalks.github.io/eva-agent/install.sh | bash
+#
+#  What it does:
+#    1. Checks for git, python3, node (installs if missing and user confirms)
+#    2. Clones the repo to ~/.eva (or updates if it exists)
+#    3. Runs the local install.sh to set up all dependencies
+#    4. Builds the standalone AppImage
+#    5. Creates a symlink so `eva` works from anywhere
+#
+#  Options (passed as env vars before the pipe):
+#    EVA_DIR=~/my-eva    — install location (default: ~/.eva)
+#    EVA_YES=1           — skip all prompts
+#    EVA_CHECK=1         — report only, don't install
+#    EVA_NO_BUILD=1      — skip AppImage build
+# ============================================================================
+
+set -euo pipefail
+
+EVA_DIR="${EVA_DIR:-$HOME/.eva}"
+EVA_YES="${EVA_YES:-0}"
+EVA_CHECK="${EVA_CHECK:-0}"
+EVA_NO_BUILD="${EVA_NO_BUILD:-0}"
+EVA_REPO="https://github.com/appatalks/eva-agent.git"
+EVA_BIN="$HOME/.local/bin"
+
+# Colors
+if [ -t 1 ]; then
+  R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[1;33m'
+  C=$'\033[0;36m'; B=$'\033[1m'; N=$'\033[0m'
+else
+  R=""; G=""; Y=""; C=""; B=""; N=""
+fi
+
+info() { printf '%s[eva]%s %s\n' "$C" "$N" "$*"; }
+ok()   { printf '%s[eva]%s %s\n' "$G" "$N" "$*"; }
+warn() { printf '%s[eva]%s %s\n' "$Y" "$N" "$*"; }
+fail() { printf '%s[eva]%s %s\n' "$R" "$N" "$*"; exit 1; }
+
+confirm() {
+  [ "$EVA_YES" = "1" ] && return 0
+  printf '%s[eva]%s %s [Y/n] ' "$Y" "$N" "$1"
+  read -r ans
+  case "$ans" in
+    [Nn]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# ── Platform detection ──────────────────────────────────────────────────────
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Linux)  PLATFORM="linux" ;;
+  Darwin) PLATFORM="macos" ;;
+  *)      fail "Unsupported OS: $OS. Eva supports Linux and macOS." ;;
+esac
+
+info "Eva AI Assistant installer"
+info "Platform: $PLATFORM ($ARCH)"
+info "Install directory: $EVA_DIR"
+echo
+
+# ── Check / install prerequisites ──────────────────────────────────────────
+check_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+install_prereq() {
+  local cmd="$1" pkg="$2"
+  if check_cmd "$cmd"; then
+    ok "$cmd found: $(command -v "$cmd")"
+    return 0
+  fi
+  warn "$cmd not found."
+  if [ "$EVA_CHECK" = "1" ]; then return 1; fi
+
+  if [ "$PLATFORM" = "linux" ]; then
+    if check_cmd apt-get; then
+      confirm "Install $pkg via apt?" && sudo apt-get update -qq && sudo apt-get install -y -qq "$pkg"
+    elif check_cmd dnf; then
+      confirm "Install $pkg via dnf?" && sudo dnf install -y "$pkg"
+    elif check_cmd pacman; then
+      confirm "Install $pkg via pacman?" && sudo pacman -S --noconfirm "$pkg"
+    else
+      fail "No supported package manager found. Install $cmd manually."
+    fi
+  elif [ "$PLATFORM" = "macos" ]; then
+    if ! check_cmd brew; then
+      confirm "Install Homebrew first?" && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+    confirm "Install $pkg via brew?" && brew install "$pkg"
+  fi
+
+  check_cmd "$cmd" || fail "Failed to install $cmd."
+  ok "$cmd installed."
+}
+
+install_prereq git git
+install_prereq python3 python3
+install_prereq node nodejs
+
+# Node version check
+NODE_MAJOR="$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)"
+if [ -n "$NODE_MAJOR" ] && [ "$NODE_MAJOR" -lt 24 ]; then
+  warn "Node.js $NODE_MAJOR found, but Eva needs 24+."
+  if [ "$PLATFORM" = "linux" ] && [ "$EVA_CHECK" != "1" ]; then
+    if confirm "Install Node.js 24 via NodeSource?"; then
+      curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+      sudo apt-get install -y nodejs
+      ok "Node.js $(node --version) installed."
+    fi
+  elif [ "$PLATFORM" = "macos" ] && [ "$EVA_CHECK" != "1" ]; then
+    confirm "Upgrade node via brew?" && brew install node@24
+  fi
+fi
+
+echo
+if [ "$EVA_CHECK" = "1" ]; then
+  info "Check mode: no changes made."
+  exit 0
+fi
+
+# ── Clone or update ────────────────────────────────────────────────────────
+if [ -d "$EVA_DIR/.git" ]; then
+  info "Updating existing installation..."
+  cd "$EVA_DIR"
+  git pull --ff-only origin main || warn "Pull failed; continuing with current version."
+else
+  info "Cloning Eva..."
+  git clone --depth 1 "$EVA_REPO" "$EVA_DIR"
+  cd "$EVA_DIR"
+fi
+
+# ── Run local installer ───────────────────────────────────────────────────
+if [ -f install.sh ]; then
+  info "Running dependency installer..."
+  INSTALL_ARGS="--yes"
+  if [ "$EVA_NO_BUILD" != "1" ]; then
+    INSTALL_ARGS="$INSTALL_ARGS --build"
+  fi
+  bash install.sh $INSTALL_ARGS
+fi
+
+# ── Create launcher symlink ───────────────────────────────────────────────
+mkdir -p "$EVA_BIN"
+
+APPIMAGE="$(find "$EVA_DIR/standalone/dist" -name '*.AppImage' -type f 2>/dev/null | sort -V | tail -1)"
+
+if [ -n "$APPIMAGE" ]; then
+  ln -sf "$APPIMAGE" "$EVA_BIN/eva"
+  ok "Symlinked: eva -> $APPIMAGE"
+else
+  # Fallback: create a launcher script that starts the bridge + opens browser
+  cat > "$EVA_BIN/eva" <<'LAUNCHER'
+#!/usr/bin/env bash
+EVA_HOME="${EVA_HOME:-$HOME/.eva}"
+cd "$EVA_HOME" || { echo "Eva not found at $EVA_HOME"; exit 1; }
+echo "Starting Eva bridge on http://localhost:8888..."
+python3 tools/acp_bridge.py &
+BRIDGE_PID=$!
+sleep 2
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "http://localhost:8888" 2>/dev/null || true
+elif command -v open >/dev/null 2>&1; then
+  open "http://localhost:8888" || true
+fi
+echo "Eva bridge running (PID $BRIDGE_PID). Press Ctrl+C to stop."
+wait $BRIDGE_PID
+LAUNCHER
+  chmod +x "$EVA_BIN/eva"
+  ok "Created launcher: $EVA_BIN/eva"
+fi
+
+# Ensure ~/.local/bin is on PATH
+case ":$PATH:" in
+  *":$EVA_BIN:"*) ;;
+  *)
+    SHELL_RC=""
+    if [ -f "$HOME/.bashrc" ]; then SHELL_RC="$HOME/.bashrc"
+    elif [ -f "$HOME/.zshrc" ]; then SHELL_RC="$HOME/.zshrc"
+    fi
+    if [ -n "$SHELL_RC" ]; then
+      if ! grep -q 'local/bin' "$SHELL_RC" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
+        info "Added ~/.local/bin to PATH in $SHELL_RC"
+      fi
+    fi
+    export PATH="$EVA_BIN:$PATH"
+    ;;
+esac
+
+echo
+echo "${B}Eva is installed.${N}"
+echo
+echo "  Run:  ${G}eva${N}"
+echo
+echo "  Update:  ${C}cd $EVA_DIR && git pull && ./install.sh --build${N}"
+echo "  Docs:    ${C}https://appatalks.github.io/eva-agent/${N}"
+echo

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,522 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eva AI Assistant</title>
+  <meta name="description" content="Eva is a voice-first AI assistant that sees, browses, controls your desktop, learns from experience, and runs scheduled tasks. Open source, local-first, no cloud lock-in.">
+  <meta name="theme-color" content="#0a0a12">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <style>
+    :root {
+      --bg: #0a0a12;
+      --bg2: #12121e;
+      --fg: #e0dfe8;
+      --fg2: #8a89a0;
+      --accent: #7c6aef;
+      --accent2: #a78bfa;
+      --glow: rgba(124, 106, 239, 0.15);
+      --border: rgba(138, 137, 160, 0.12);
+      --card: #161625;
+      --radius: 12px;
+      --max: 960px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+    a { color: var(--accent2); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code {
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      background: var(--bg2);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.9em;
+    }
+
+    /* ── Header ─────────────────────────────────────────────── */
+    header {
+      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+      background: rgba(10, 10, 18, 0.85);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .header-inner {
+      max-width: var(--max); margin: 0 auto;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 24px;
+    }
+    .logo {
+      font-size: 1.2rem; font-weight: 700; color: var(--fg);
+      display: flex; align-items: center; gap: 8px;
+    }
+    .logo-dot {
+      width: 10px; height: 10px; border-radius: 50%;
+      background: var(--accent); box-shadow: 0 0 8px var(--accent);
+    }
+    nav { display: flex; gap: 20px; align-items: center; }
+    nav a { color: var(--fg2); font-size: 0.9rem; transition: color 0.2s; }
+    nav a:hover { color: var(--fg); text-decoration: none; }
+    .btn {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 8px 18px; border-radius: 8px; font-weight: 500;
+      font-size: 0.9rem; transition: all 0.2s; border: none; cursor: pointer;
+    }
+    .btn-primary {
+      background: var(--accent); color: #fff;
+      box-shadow: 0 2px 12px rgba(124, 106, 239, 0.3);
+    }
+    .btn-primary:hover { background: var(--accent2); text-decoration: none; }
+    .btn-ghost {
+      background: transparent; color: var(--fg2);
+      border: 1px solid var(--border);
+    }
+    .btn-ghost:hover { color: var(--fg); border-color: var(--fg2); text-decoration: none; }
+
+    /* ── Hero ────────────────────────────────────────────────── */
+    .hero {
+      max-width: var(--max); margin: 0 auto;
+      padding: 140px 24px 80px;
+      text-align: center;
+    }
+    .hero h1 {
+      font-size: clamp(2.2rem, 5vw, 3.4rem);
+      font-weight: 800; line-height: 1.15;
+      margin-bottom: 16px;
+    }
+    .hero h1 .gradient {
+      background: linear-gradient(135deg, var(--accent), var(--accent2), #c084fc);
+      -webkit-background-clip: text; background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .hero p {
+      font-size: 1.15rem; color: var(--fg2);
+      max-width: 600px; margin: 0 auto 32px;
+    }
+    .hero-actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+
+    /* ── Install block ──────────────────────────────────────── */
+    .install-block {
+      max-width: 640px; margin: 48px auto 0;
+      background: var(--bg2); border: 1px solid var(--border);
+      border-radius: var(--radius); overflow: hidden;
+    }
+    .install-bar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 8px 16px;
+      background: rgba(255,255,255,0.03);
+      border-bottom: 1px solid var(--border);
+    }
+    .install-dots { display: flex; gap: 6px; }
+    .install-dots span {
+      width: 10px; height: 10px; border-radius: 50%;
+      background: rgba(255,255,255,0.08);
+    }
+    .install-copy {
+      background: none; border: 1px solid var(--border); color: var(--fg2);
+      padding: 4px 10px; border-radius: 6px; font-size: 0.75rem; cursor: pointer;
+      transition: all 0.2s;
+    }
+    .install-copy:hover { color: var(--fg); border-color: var(--fg2); }
+    .install-code {
+      padding: 20px 24px; font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.95rem; color: var(--accent2); user-select: all;
+      overflow-x: auto; white-space: nowrap;
+    }
+    .install-code .comment { color: var(--fg2); }
+
+    /* ── Features ────────────────────────────────────────────── */
+    .features {
+      max-width: var(--max); margin: 0 auto;
+      padding: 80px 24px;
+    }
+    .features h2 {
+      text-align: center; font-size: 1.8rem; margin-bottom: 48px;
+    }
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+    }
+    .feature-card {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 28px;
+      transition: border-color 0.2s, box-shadow 0.2s;
+    }
+    .feature-card:hover {
+      border-color: rgba(124, 106, 239, 0.3);
+      box-shadow: 0 4px 24px var(--glow);
+    }
+    .feature-icon {
+      width: 40px; height: 40px; border-radius: 10px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 1.3rem; margin-bottom: 14px;
+      background: var(--glow);
+    }
+    .feature-card h3 { font-size: 1.05rem; margin-bottom: 8px; }
+    .feature-card p { color: var(--fg2); font-size: 0.9rem; line-height: 1.55; }
+
+    /* ── Architecture ────────────────────────────────────────── */
+    .arch {
+      max-width: var(--max); margin: 0 auto;
+      padding: 40px 24px 80px;
+    }
+    .arch h2 { text-align: center; font-size: 1.8rem; margin-bottom: 16px; }
+    .arch-sub { text-align: center; color: var(--fg2); margin-bottom: 40px; max-width: 600px; margin-left: auto; margin-right: auto; }
+    .arch-cols {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+    }
+    .arch-col {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 24px;
+    }
+    .arch-col h4 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--accent2); margin-bottom: 10px; }
+    .arch-col ul { list-style: none; }
+    .arch-col li { font-size: 0.85rem; color: var(--fg2); padding: 3px 0; }
+    .arch-col li::before { content: ""; display: inline-block; width: 4px; height: 4px; border-radius: 50%; background: var(--accent); margin-right: 8px; vertical-align: middle; }
+
+    /* ── Comparison ──────────────────────────────────────────── */
+    .compare {
+      max-width: var(--max); margin: 0 auto; padding: 0 24px 80px;
+    }
+    .compare h2 { text-align: center; font-size: 1.8rem; margin-bottom: 40px; }
+    .compare-table {
+      width: 100%; border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+    .compare-table th {
+      text-align: left; padding: 10px 14px;
+      border-bottom: 2px solid var(--border);
+      color: var(--fg2); font-weight: 600; font-size: 0.8rem;
+      text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .compare-table td {
+      padding: 10px 14px; border-bottom: 1px solid var(--border);
+      color: var(--fg2);
+    }
+    .compare-table td:first-child { color: var(--fg); font-weight: 500; }
+    .compare-table .yes { color: var(--accent2); }
+    .compare-table .no { opacity: 0.4; }
+
+    /* ── CTA ─────────────────────────────────────────────────── */
+    .cta {
+      text-align: center; padding: 80px 24px;
+      background: linear-gradient(180deg, transparent, var(--bg2));
+    }
+    .cta h2 { font-size: 1.8rem; margin-bottom: 12px; }
+    .cta p { color: var(--fg2); margin-bottom: 28px; }
+
+    /* ── Footer ──────────────────────────────────────────────── */
+    footer {
+      text-align: center; padding: 32px 24px;
+      color: var(--fg2); font-size: 0.8rem;
+      border-top: 1px solid var(--border);
+    }
+    footer a { color: var(--fg2); }
+
+    /* ── Responsive ──────────────────────────────────────────── */
+    @media (max-width: 640px) {
+      .header-inner { padding: 10px 16px; }
+      nav a:not(.btn) { display: none; }
+      .hero { padding: 120px 16px 60px; }
+      .feature-grid { grid-template-columns: 1fr; }
+      .arch-cols { grid-template-columns: 1fr 1fr; }
+      .compare-table { font-size: 0.78rem; }
+      .compare-table th, .compare-table td { padding: 8px 10px; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- Header -->
+<header>
+  <div class="header-inner">
+    <div class="logo">
+      <span class="logo-dot"></span> Eva
+    </div>
+    <nav>
+      <a href="#features">Features</a>
+      <a href="#architecture">Architecture</a>
+      <a href="#compare">Compare</a>
+      <a href="https://github.com/appatalks/eva-agent" class="btn btn-ghost">GitHub</a>
+      <a href="#install" class="btn btn-primary">Install</a>
+    </nav>
+  </div>
+</header>
+
+<!-- Hero -->
+<section class="hero" id="install">
+  <h1>The AI assistant that<br><span class="gradient">lives on your desktop</span></h1>
+  <p>Eva sees through your camera, controls your browser and desktop, remembers everything, learns from experience, and runs tasks on a schedule. Local-first. Open source. No cloud lock-in.</p>
+  <div class="hero-actions">
+    <a href="https://github.com/appatalks/eva-agent" class="btn btn-primary">View on GitHub</a>
+    <a href="https://github.com/appatalks/eva-agent/releases" class="btn btn-ghost">Download AppImage</a>
+  </div>
+
+  <div class="install-block">
+    <div class="install-bar">
+      <div class="install-dots"><span></span><span></span><span></span></div>
+      <button class="install-copy" onclick="navigator.clipboard.writeText('curl -fsSL https://appatalks.github.io/eva-agent/get-eva.sh | bash');this.textContent='Copied!'">Copy</button>
+    </div>
+    <div class="install-code">
+      <span class="comment"># Linux or macOS</span><br>
+      curl -fsSL https://appatalks.github.io/eva-agent/get-eva.sh | bash
+    </div>
+  </div>
+</section>
+
+<!-- Features -->
+<section class="features" id="features">
+  <h2>Everything an assistant should be</h2>
+  <div class="feature-grid">
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F441;</div>
+      <h3>Camera vision</h3>
+      <p>Eva sees through your webcam. Face-detection auto-wake, on-demand "look" commands, and ambient presence sensing. All frames stay local unless you ask her to describe what she sees.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F310;</div>
+      <h3>Browser agent</h3>
+      <p>Controls a real Chromium browser through the DOM. Persistent login, precise click-by-element, hybrid vision fallback. Shops, fills forms, navigates, and pauses for confirmation on purchases.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F5A5;</div>
+      <h3>Desktop control</h3>
+      <p>Drives your actual mouse and keyboard to operate any application. Focus windows, open apps, click buttons. Optional AT-SPI semantic control via computer-use-linux MCP for Wayland support.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F3A4;</div>
+      <h3>Voice-first interface</h3>
+      <p>Full-screen voice orb with wake/barge-in, echo management, and spoken progress narration. TTS via OpenAI, AWS Polly, browser, or Bark. Eva speaks her results, not just displays them.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F9E0;</div>
+      <h3>Persistent memory</h3>
+      <p>Kusto/Azure Data Explorer-backed memory with conversation history, emotion tracking, knowledge graph, and semantic recall. She remembers what you talked about last week.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F4DA;</div>
+      <h3>Self-improving skills</h3>
+      <p>Eva auto-extracts reusable skills from successful complex tasks. Skills are stored as drafts for your review and applied automatically to matching future requests.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x23F0;</div>
+      <h3>Cron scheduler</h3>
+      <p>Schedule recurring tasks with standard cron expressions. Morning briefings, periodic market checks, nightly reports. Eva runs each prompt through ACP at the scheduled time.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F500;</div>
+      <h3>Parallel subagents</h3>
+      <p>Spawn up to 4 isolated subagent tasks that run concurrently. Results delivered via notifications. Break complex work into parallel streams.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F50C;</div>
+      <h3>Multi-provider</h3>
+      <p>OpenAI, Google Gemini, GitHub Copilot, local models via lm-studio. Switch providers from a dropdown. No code changes, no lock-in. Bring any model you want.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F6E1;</div>
+      <h3>Doctor diagnostics</h3>
+      <p>Structured JSON readiness report for every subsystem: ACP, browser, desktop, camera, Kusto, cron, cognition. Tells you exactly what's working and what needs fixing.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x2699;</div>
+      <h3>MCP ecosystem</h3>
+      <p>Azure, GitHub, Kusto, and computer-use-linux MCP servers configurable from the UI. Extend Eva's capabilities with any MCP-compatible tool server.</p>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">&#x1F3AF;</div>
+      <h3>Cognitive layer</h3>
+      <p>Eva + Reviewer dual-agent pipeline with configurable models and max review cycles. Every response is drafted, critiqued, and refined before you see it.</p>
+    </div>
+
+  </div>
+</section>
+
+<!-- Architecture -->
+<section class="arch" id="architecture">
+  <h2>How it's built</h2>
+  <p class="arch-sub">No build step. No framework. Pure HTML, CSS, and JavaScript in the browser, backed by a Python bridge that connects to any LLM provider.</p>
+  <div class="arch-cols">
+    <div class="arch-col">
+      <h4>Frontend</h4>
+      <ul>
+        <li>Vanilla JS, no build</li>
+        <li>Electron AppImage</li>
+        <li>Voice orb + chat UI</li>
+        <li>Settings panel</li>
+        <li>LCARS + Eva themes</li>
+      </ul>
+    </div>
+    <div class="arch-col">
+      <h4>Bridge</h4>
+      <ul>
+        <li>Python HTTP server</li>
+        <li>ACP / Copilot CLI</li>
+        <li>MCP server management</li>
+        <li>Background loop</li>
+        <li>Cron scheduler</li>
+      </ul>
+    </div>
+    <div class="arch-col">
+      <h4>Agents</h4>
+      <ul>
+        <li>Browser (Playwright)</li>
+        <li>Desktop (PyAutoGUI)</li>
+        <li>Camera (OpenCV)</li>
+        <li>Subagent spawner</li>
+        <li>Cognition pipeline</li>
+      </ul>
+    </div>
+    <div class="arch-col">
+      <h4>Storage</h4>
+      <ul>
+        <li>Azure Data Explorer</li>
+        <li>Kusto/KQL queries</li>
+        <li>Skills in ADX</li>
+        <li>Local prefs JSON</li>
+        <li>Semantic embeddings</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- Comparison -->
+<section class="compare" id="compare">
+  <h2>Eva vs the field</h2>
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th></th>
+        <th>Eva</th>
+        <th>Hermes Agent</th>
+        <th>ChatGPT Desktop</th>
+        <th>Claude Desktop</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Open source</td>
+        <td class="yes">Yes (MIT)</td>
+        <td class="yes">Yes (MIT)</td>
+        <td class="no">No</td>
+        <td class="no">No</td>
+      </tr>
+      <tr>
+        <td>Camera/vision</td>
+        <td class="yes">Built-in</td>
+        <td class="no">No</td>
+        <td class="no">No</td>
+        <td class="no">No</td>
+      </tr>
+      <tr>
+        <td>Browser automation</td>
+        <td class="yes">Built-in (DOM + vision)</td>
+        <td>Via MCP</td>
+        <td class="no">No</td>
+        <td>Via MCP</td>
+      </tr>
+      <tr>
+        <td>Desktop control</td>
+        <td class="yes">Built-in + MCP</td>
+        <td>Via MCP</td>
+        <td class="no">No</td>
+        <td>Via MCP</td>
+      </tr>
+      <tr>
+        <td>Voice interface</td>
+        <td class="yes">Full voice view</td>
+        <td>Transcription only</td>
+        <td class="yes">Yes</td>
+        <td class="no">No</td>
+      </tr>
+      <tr>
+        <td>Self-improving skills</td>
+        <td class="yes">Auto-learn</td>
+        <td class="yes">Yes</td>
+        <td class="no">No</td>
+        <td class="no">No</td>
+      </tr>
+      <tr>
+        <td>Scheduled tasks</td>
+        <td class="yes">Cron</td>
+        <td class="yes">Cron</td>
+        <td class="no">No</td>
+        <td class="no">No</td>
+      </tr>
+      <tr>
+        <td>Persistent memory</td>
+        <td class="yes">Kusto/ADX</td>
+        <td class="yes">FTS5 + files</td>
+        <td>Limited</td>
+        <td>Limited</td>
+      </tr>
+      <tr>
+        <td>Multi-provider</td>
+        <td class="yes">4+ providers</td>
+        <td class="yes">200+ models</td>
+        <td class="no">OpenAI only</td>
+        <td class="no">Anthropic only</td>
+      </tr>
+      <tr>
+        <td>No build step</td>
+        <td class="yes">Yes</td>
+        <td class="no">pip install</td>
+        <td class="no">N/A</td>
+        <td class="no">N/A</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- CTA -->
+<section class="cta">
+  <h2>Ready to try it?</h2>
+  <p>One command. No API keys required to start (bring your own or use Copilot).</p>
+  <div class="hero-actions">
+    <a href="https://github.com/appatalks/eva-agent" class="btn btn-primary">Get started</a>
+    <a href="https://github.com/appatalks/eva-agent/issues" class="btn btn-ghost">Report an issue</a>
+  </div>
+</section>
+
+<!-- Footer -->
+<footer>
+  <p>Eva AI Assistant &mdash; MIT License &mdash; Built by <a href="https://github.com/appatalks">appatalks</a></p>
+</footer>
+
+<script>
+// Smooth reveal on scroll
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(e => {
+    if (e.isIntersecting) { e.target.style.opacity = '1'; e.target.style.transform = 'translateY(0)'; }
+  });
+}, { threshold: 0.1 });
+document.querySelectorAll('.feature-card, .arch-col').forEach(el => {
+  el.style.opacity = '0';
+  el.style.transform = 'translateY(20px)';
+  el.style.transition = 'opacity 0.5s, transform 0.5s';
+  observer.observe(el);
+});
+</script>
+
+</body>
+</html>

--- a/get-eva.sh
+++ b/get-eva.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# ============================================================================
+#  Eva AI Assistant — remote installer
+#
+#  curl -fsSL https://appatalks.github.io/eva-agent/install.sh | bash
+#
+#  What it does:
+#    1. Checks for git, python3, node (installs if missing and user confirms)
+#    2. Clones the repo to ~/.eva (or updates if it exists)
+#    3. Runs the local install.sh to set up all dependencies
+#    4. Builds the standalone AppImage
+#    5. Creates a symlink so `eva` works from anywhere
+#
+#  Options (passed as env vars before the pipe):
+#    EVA_DIR=~/my-eva    — install location (default: ~/.eva)
+#    EVA_YES=1           — skip all prompts
+#    EVA_CHECK=1         — report only, don't install
+#    EVA_NO_BUILD=1      — skip AppImage build
+# ============================================================================
+
+set -euo pipefail
+
+EVA_DIR="${EVA_DIR:-$HOME/.eva}"
+EVA_YES="${EVA_YES:-0}"
+EVA_CHECK="${EVA_CHECK:-0}"
+EVA_NO_BUILD="${EVA_NO_BUILD:-0}"
+EVA_REPO="https://github.com/appatalks/eva-agent.git"
+EVA_BIN="$HOME/.local/bin"
+
+# Colors
+if [ -t 1 ]; then
+  R=$'\033[0;31m'; G=$'\033[0;32m'; Y=$'\033[1;33m'
+  C=$'\033[0;36m'; B=$'\033[1m'; N=$'\033[0m'
+else
+  R=""; G=""; Y=""; C=""; B=""; N=""
+fi
+
+info() { printf '%s[eva]%s %s\n' "$C" "$N" "$*"; }
+ok()   { printf '%s[eva]%s %s\n' "$G" "$N" "$*"; }
+warn() { printf '%s[eva]%s %s\n' "$Y" "$N" "$*"; }
+fail() { printf '%s[eva]%s %s\n' "$R" "$N" "$*"; exit 1; }
+
+confirm() {
+  [ "$EVA_YES" = "1" ] && return 0
+  printf '%s[eva]%s %s [Y/n] ' "$Y" "$N" "$1"
+  read -r ans
+  case "$ans" in
+    [Nn]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# ── Platform detection ──────────────────────────────────────────────────────
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Linux)  PLATFORM="linux" ;;
+  Darwin) PLATFORM="macos" ;;
+  *)      fail "Unsupported OS: $OS. Eva supports Linux and macOS." ;;
+esac
+
+info "Eva AI Assistant installer"
+info "Platform: $PLATFORM ($ARCH)"
+info "Install directory: $EVA_DIR"
+echo
+
+# ── Check / install prerequisites ──────────────────────────────────────────
+check_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+install_prereq() {
+  local cmd="$1" pkg="$2"
+  if check_cmd "$cmd"; then
+    ok "$cmd found: $(command -v "$cmd")"
+    return 0
+  fi
+  warn "$cmd not found."
+  if [ "$EVA_CHECK" = "1" ]; then return 1; fi
+
+  if [ "$PLATFORM" = "linux" ]; then
+    if check_cmd apt-get; then
+      confirm "Install $pkg via apt?" && sudo apt-get update -qq && sudo apt-get install -y -qq "$pkg"
+    elif check_cmd dnf; then
+      confirm "Install $pkg via dnf?" && sudo dnf install -y "$pkg"
+    elif check_cmd pacman; then
+      confirm "Install $pkg via pacman?" && sudo pacman -S --noconfirm "$pkg"
+    else
+      fail "No supported package manager found. Install $cmd manually."
+    fi
+  elif [ "$PLATFORM" = "macos" ]; then
+    if ! check_cmd brew; then
+      confirm "Install Homebrew first?" && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+    confirm "Install $pkg via brew?" && brew install "$pkg"
+  fi
+
+  check_cmd "$cmd" || fail "Failed to install $cmd."
+  ok "$cmd installed."
+}
+
+install_prereq git git
+install_prereq python3 python3
+install_prereq node nodejs
+
+# Node version check
+NODE_MAJOR="$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)"
+if [ -n "$NODE_MAJOR" ] && [ "$NODE_MAJOR" -lt 24 ]; then
+  warn "Node.js $NODE_MAJOR found, but Eva needs 24+."
+  if [ "$PLATFORM" = "linux" ] && [ "$EVA_CHECK" != "1" ]; then
+    if confirm "Install Node.js 24 via NodeSource?"; then
+      curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+      sudo apt-get install -y nodejs
+      ok "Node.js $(node --version) installed."
+    fi
+  elif [ "$PLATFORM" = "macos" ] && [ "$EVA_CHECK" != "1" ]; then
+    confirm "Upgrade node via brew?" && brew install node@24
+  fi
+fi
+
+echo
+if [ "$EVA_CHECK" = "1" ]; then
+  info "Check mode: no changes made."
+  exit 0
+fi
+
+# ── Clone or update ────────────────────────────────────────────────────────
+if [ -d "$EVA_DIR/.git" ]; then
+  info "Updating existing installation..."
+  cd "$EVA_DIR"
+  git pull --ff-only origin main || warn "Pull failed; continuing with current version."
+else
+  info "Cloning Eva..."
+  git clone --depth 1 "$EVA_REPO" "$EVA_DIR"
+  cd "$EVA_DIR"
+fi
+
+# ── Run local installer ───────────────────────────────────────────────────
+if [ -f install.sh ]; then
+  info "Running dependency installer..."
+  INSTALL_ARGS="--yes"
+  if [ "$EVA_NO_BUILD" != "1" ]; then
+    INSTALL_ARGS="$INSTALL_ARGS --build"
+  fi
+  bash install.sh $INSTALL_ARGS
+fi
+
+# ── Create launcher symlink ───────────────────────────────────────────────
+mkdir -p "$EVA_BIN"
+
+APPIMAGE="$(find "$EVA_DIR/standalone/dist" -name '*.AppImage' -type f 2>/dev/null | sort -V | tail -1)"
+
+if [ -n "$APPIMAGE" ]; then
+  ln -sf "$APPIMAGE" "$EVA_BIN/eva"
+  ok "Symlinked: eva -> $APPIMAGE"
+else
+  # Fallback: create a launcher script that starts the bridge + opens browser
+  cat > "$EVA_BIN/eva" <<'LAUNCHER'
+#!/usr/bin/env bash
+EVA_HOME="${EVA_HOME:-$HOME/.eva}"
+cd "$EVA_HOME" || { echo "Eva not found at $EVA_HOME"; exit 1; }
+echo "Starting Eva bridge on http://localhost:8888..."
+python3 tools/acp_bridge.py &
+BRIDGE_PID=$!
+sleep 2
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "http://localhost:8888" 2>/dev/null || true
+elif command -v open >/dev/null 2>&1; then
+  open "http://localhost:8888" || true
+fi
+echo "Eva bridge running (PID $BRIDGE_PID). Press Ctrl+C to stop."
+wait $BRIDGE_PID
+LAUNCHER
+  chmod +x "$EVA_BIN/eva"
+  ok "Created launcher: $EVA_BIN/eva"
+fi
+
+# Ensure ~/.local/bin is on PATH
+case ":$PATH:" in
+  *":$EVA_BIN:"*) ;;
+  *)
+    SHELL_RC=""
+    if [ -f "$HOME/.bashrc" ]; then SHELL_RC="$HOME/.bashrc"
+    elif [ -f "$HOME/.zshrc" ]; then SHELL_RC="$HOME/.zshrc"
+    fi
+    if [ -n "$SHELL_RC" ]; then
+      if ! grep -q 'local/bin' "$SHELL_RC" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
+        info "Added ~/.local/bin to PATH in $SHELL_RC"
+      fi
+    fi
+    export PATH="$EVA_BIN:$PATH"
+    ;;
+esac
+
+echo
+echo "${B}Eva is installed.${N}"
+echo
+echo "  Run:  ${G}eva${N}"
+echo
+echo "  Update:  ${C}cd $EVA_DIR && git pull && ./install.sh --build${N}"
+echo "  Docs:    ${C}https://appatalks.github.io/eva-agent/${N}"
+echo

--- a/index.html
+++ b/index.html
@@ -261,6 +261,7 @@
       <button class="settings-tab" data-stab="prompts" role="tab">Prompts</button>
       <button class="settings-tab" data-stab="goals" role="tab">Goals</button>
       <button class="settings-tab" data-stab="background" role="tab">Background</button>
+      <button class="settings-tab" data-stab="cron" role="tab">Cron</button>
       <button class="settings-tab" data-stab="mcp" role="tab">MCP</button>
     </div>
     <div class="settings-body">
@@ -319,6 +320,8 @@
           <span>Active goals: <span id="evaActiveGoalsCount">0</span></span><br>
           <span id="evaStandaloneVersion" style="display:none"></span>
         </div>
+        <button type="button" class="auth-toggle" id="doctorButton" style="margin-top:8px;width:100%;text-align:center" onclick="runDoctor()">Run diagnostics</button>
+        <div id="doctorReport" class="mcp-status" aria-live="polite" style="margin-top:8px;display:none;white-space:pre-wrap;font-family:monospace;font-size:11px;max-height:300px;overflow-y:auto"></div>
       </div>
 
       <!-- Models Tab -->
@@ -699,6 +702,34 @@
         <div id="backgroundActivity" class="background-list"></div>
       </div>
 
+      <!-- Cron Tab -->
+      <div class="settings-panel" data-stab="cron">
+        <p class="auth-note">Schedule recurring tasks with cron expressions. Eva runs each task's prompt through ACP at the scheduled time. Requires the background loop to be running.</p>
+
+        <div class="mcp-preset">
+          <div class="auth-field">
+            <label for="cronLabel">Task name</label>
+            <input type="text" id="cronLabel" maxlength="120" placeholder="e.g. Morning briefing">
+          </div>
+          <div class="auth-field">
+            <label for="cronSchedule">Schedule (cron expression)</label>
+            <input type="text" id="cronSchedule" maxlength="60" placeholder="0 8 * * 1-5" title="minute hour day-of-month month day-of-week">
+            <p class="prompt-hint" style="margin-top:2px">Format: minute hour dom month dow. Examples: <code>0 8 * * 1-5</code> (weekdays 8am), <code>*/30 * * * *</code> (every 30min), <code>0 0 * * 0</code> (Sunday midnight)</p>
+          </div>
+          <div class="auth-field">
+            <label for="cronPrompt">Prompt (what Eva should do)</label>
+            <textarea id="cronPrompt" rows="3" maxlength="2000" placeholder="Give me a morning briefing: weather, calendar, top news, and any alerts."></textarea>
+          </div>
+          <div class="background-actions">
+            <button type="button" class="auth-save" id="cronAddButton" onclick="cronAdd()">Add task</button>
+            <button type="button" class="auth-toggle" onclick="cronRefresh()">Refresh</button>
+          </div>
+        </div>
+
+        <div id="cronStatus" class="mcp-status" aria-live="polite"></div>
+        <div id="cronList" class="background-list"></div>
+      </div>
+
       <!-- MCP Tab -->
       <div class="settings-panel" data-stab="mcp">
         <p class="auth-note">MCP (Model Context Protocol) servers extend the AI with tools for Azure, GitHub, and more. Requires the ACP bridge (<code>tools/acp_bridge.py</code>).</p>
@@ -737,6 +768,15 @@
             <button type="button" id="mcpEnsureTablesButton" class="auth-toggle" style="margin-top:6px;width:100%;text-align:center" disabled>Create missing tables</button>
             <div id="mcpSeedStatus" class="mcp-status" aria-live="polite" style="margin-top:8px"></div>
           </div>
+        </div>
+
+        <div class="mcp-preset">
+          <label>
+            <input type="checkbox" id="mcpComputerUse"> <strong>Computer Use Linux (Desktop MCP)</strong>
+          </label>
+          <p class="prompt-hint">AT-SPI accessibility trees, screenshots, clicks, scrolls, keystrokes. Wayland-first, X11 fallback.<br>
+            Semantic selectors (role/name) instead of pixel coordinates. Replaces PyAutoGUI for desktop control.<br>
+            Install: <code>npm install -g @agent-sh/computer-use-linux</code> then <code>computer-use-linux setup</code></p>
         </div>
 
         <div id="mcpStatus" class="mcp-status"></div>

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -27,13 +27,16 @@ The server exposes a single endpoint:
 """
 
 import argparse
+import base64
 import copy
 import datetime
 import hashlib
 import json
 import mimetypes
 import os
+import platform
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -1035,6 +1038,198 @@ _bg_last_error = ""
 _bg_last_activity = {}
 _last_user_activity_ts = 0.0
 _bg_tick_lock = threading.Lock()
+
+# ---------------------------------------------------------------------------
+# Cron scheduler — user-defined scheduled tasks
+# ---------------------------------------------------------------------------
+_CRON_TASKS_PATH = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+    "eva-standalone", "cron_tasks.json"
+)
+_cron_tasks = []      # list of {id, label, schedule, prompt, enabled, last_run, next_run, created_at}
+_cron_lock = threading.Lock()
+
+
+def _load_cron_tasks():
+    global _cron_tasks
+    try:
+        with open(_CRON_TASKS_PATH, "r") as f:
+            _cron_tasks = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        _cron_tasks = []
+
+
+def _save_cron_tasks():
+    os.makedirs(os.path.dirname(_CRON_TASKS_PATH), exist_ok=True)
+    with open(_CRON_TASKS_PATH, "w") as f:
+        json.dump(_cron_tasks, f, indent=2)
+
+
+def _parse_cron_expr(expr):
+    """Parse a 5-field cron expression into (minute, hour, dom, month, dow) tuples.
+    Each field is a set of valid integers, or None for wildcard (*)."""
+    parts = (expr or "").strip().split()
+    if len(parts) != 5:
+        return None, "expected 5 fields (minute hour dom month dow)"
+    ranges = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 6)]
+    parsed = []
+    for i, (field, (lo, hi)) in enumerate(zip(parts, ranges)):
+        if field == "*":
+            parsed.append(None)
+            continue
+        vals = set()
+        for segment in field.split(","):
+            step_parts = segment.split("/", 1)
+            range_part = step_parts[0]
+            step = int(step_parts[1]) if len(step_parts) > 1 else 1
+            if step < 1:
+                return None, f"invalid step in field {i}"
+            if range_part == "*":
+                vals.update(range(lo, hi + 1, step))
+                continue
+            dash = range_part.split("-", 1)
+            try:
+                a = int(dash[0])
+                b = int(dash[1]) if len(dash) > 1 else a
+            except ValueError:
+                return None, f"invalid value in field {i}"
+            if a < lo or b > hi or a > b:
+                return None, f"out of range in field {i}"
+            vals.update(range(a, b + 1, step))
+        parsed.append(vals)
+    return tuple(parsed), ""
+
+
+def _cron_matches(parsed, dt):
+    """Check if a datetime matches a parsed cron expression."""
+    minute, hour, dom, month, dow = parsed
+    if minute is not None and dt.minute not in minute:
+        return False
+    if hour is not None and dt.hour not in hour:
+        return False
+    if dom is not None and dt.day not in dom:
+        return False
+    if month is not None and dt.month not in month:
+        return False
+    if dow is not None:
+        # Cron: 0=Sunday, Python weekday(): 0=Monday. Convert.
+        cron_dow = (dt.weekday() + 1) % 7
+        if cron_dow not in dow:
+            return False
+    return True
+
+
+def _cron_next_run(expr, after_dt=None):
+    """Compute the next run time for a cron expression (up to 48h ahead)."""
+    parsed, err = _parse_cron_expr(expr)
+    if err or parsed is None:
+        return None
+    if after_dt is None:
+        after_dt = datetime.datetime.now(datetime.timezone.utc)
+    # Scan minute by minute for up to 48 hours
+    candidate = after_dt.replace(second=0, microsecond=0) + datetime.timedelta(minutes=1)
+    for _ in range(48 * 60):
+        if _cron_matches(parsed, candidate):
+            return candidate.isoformat()
+        candidate += datetime.timedelta(minutes=1)
+    return None
+
+
+def _cron_tick():
+    """Called from the background loop worker. Runs any due cron tasks."""
+    if not _cron_tasks:
+        return
+    now = datetime.datetime.now(datetime.timezone.utc)
+    now_iso = now.isoformat()
+    ran = []
+    with _cron_lock:
+        for task in _cron_tasks:
+            if not task.get("enabled", True):
+                continue
+            parsed, err = _parse_cron_expr(task.get("schedule", ""))
+            if err or parsed is None:
+                continue
+            if not _cron_matches(parsed, now):
+                continue
+            # Don't re-run within same minute
+            last = task.get("last_run", "")
+            if last and last[:16] == now_iso[:16]:
+                continue
+            ran.append(task)
+    for task in ran:
+        prompt = task.get("prompt", "")
+        label = task.get("label", "cron task")
+        print(f"[Cron] Running: {label}")
+        try:
+            _cron_execute_task(task["id"], prompt, label)
+        except Exception as e:
+            print(f"[Cron] Error running {label}: {e}")
+        with _cron_lock:
+            task["last_run"] = now_iso
+            task["next_run"] = _cron_next_run(task.get("schedule", ""), now)
+            _save_cron_tasks()
+
+
+def _cron_execute_task(task_id, prompt, label):
+    """Execute a cron task by sending its prompt through ACP."""
+    if not acp_client or not acp_client.alive:
+        print(f"[Cron] ACP not available for task {label}")
+        return
+    messages = [{"role": "user", "content": f"[Scheduled task: {label}] {prompt}"}]
+    try:
+        result = acp_client.send_prompt(messages)
+        if result:
+            # Push result as a notification
+            _push_notification(f"Cron: {label}", str(result)[:500], channel="chat")
+    except Exception as e:
+        print(f"[Cron] Task execution error: {e}")
+
+
+def _push_notification(title, body, channel="chat"):
+    """Push an internal notification into the notification ring."""
+    note = {
+        "id": "n-" + uuid.uuid4().hex[:8],
+        "title": title,
+        "body": body[:500],
+        "channel": channel,
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "seen": False,
+    }
+    with _notify_lock:
+        _notify_ring.append(note)
+        if len(_notify_ring) > _NOTIFY_RING_MAX:
+            del _notify_ring[:-_NOTIFY_RING_MAX]
+
+# ---------------------------------------------------------------------------
+# Subagent parallelism — spawn isolated ACP tasks that run concurrently
+# ---------------------------------------------------------------------------
+_subagent_tasks = {}  # task_id -> {id, label, prompt, status, result, started_at, ended_at, thread}
+_subagent_lock = threading.Lock()
+_SUBAGENT_MAX = 4
+
+
+def _subagent_worker(task_id, prompt, label):
+    """Run a single subagent task in its own thread using the existing ACP pool."""
+    with _subagent_lock:
+        task = _subagent_tasks.get(task_id)
+        if not task:
+            return
+    try:
+        if not acp_client or not acp_client.alive:
+            raise RuntimeError("ACP not available")
+        messages = [{"role": "user", "content": f"[Subagent task: {label}] {prompt}"}]
+        result = acp_client.send_prompt(messages)
+        with _subagent_lock:
+            task["status"] = "done"
+            task["result"] = str(result or "")[:4000]
+            task["ended_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        _push_notification(f"Subagent done: {label}", str(result or "")[:300], channel="chat")
+    except Exception as e:
+        with _subagent_lock:
+            task["status"] = "error"
+            task["result"] = str(e)[:500]
+            task["ended_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        _push_notification(f"Subagent failed: {label}", str(e)[:300], channel="chat")
 
 
 def _is_loopback_bind():
@@ -4324,8 +4519,19 @@ def _run_background_tick(trigger="scheduled"):
 
 
 def _bg_loop_worker():
+    _load_cron_tasks()
     next_due = time.time() + max(1, int(_bg_loop_interval_seconds or 7200))
+    _cron_last_minute = -1
     while not _bg_loop_stop.is_set():
+        # Cron: check every ~30s regardless of background loop enabled state
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
+        if now_utc.minute != _cron_last_minute:
+            _cron_last_minute = now_utc.minute
+            try:
+                _cron_tick()
+            except Exception as e:
+                print(f"[Cron] tick error: {e}")
+
         if not _bg_loop_enabled:
             next_due = time.time() + max(1, int(_bg_loop_interval_seconds or 7200))
             _bg_loop_stop.wait(5)
@@ -4568,12 +4774,18 @@ class BridgeHandler(BaseHTTPRequestHandler):
         parsed_path = urllib.parse.urlparse(self.path).path
         if parsed_path == "/health":
             self._health()
+        elif parsed_path == "/v1/doctor":
+            self._doctor()
         elif parsed_path == "/v1/models":
             self._models()
         elif parsed_path == "/v1/mcp":
             self._mcp_status()
         elif parsed_path == "/v1/mcp/config":
             self._mcp_persisted_config()
+        elif parsed_path == "/v1/cron":
+            self._cron_list()
+        elif parsed_path == "/v1/subagent/status":
+            self._subagent_status()
         elif parsed_path == "/v1/telemetry":
             self._telemetry_report()
         elif parsed_path == "/v1/logs":
@@ -4626,6 +4838,12 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._aig_chat()
         elif parsed_path == "/v1/telemetry":
             self._telemetry_ingest()
+        elif parsed_path == "/v1/cron":
+            self._cron_create()
+        elif parsed_path == "/v1/skills/auto-learn":
+            self._skills_auto_learn()
+        elif parsed_path == "/v1/subagent/spawn":
+            self._subagent_spawn()
         elif parsed_path == "/v1/browser/run":
             self._browser_run()
         elif parsed_path == "/v1/desktop/run":
@@ -4675,6 +4893,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._goals_patch(urllib.parse.unquote(parsed_path.split("/v1/goals/", 1)[1]))
         elif parsed_path.startswith("/v1/skills/"):
             self._skills_patch(urllib.parse.unquote(parsed_path.split("/v1/skills/", 1)[1]))
+        elif parsed_path.startswith("/v1/cron/"):
+            self._cron_update(urllib.parse.unquote(parsed_path.split("/v1/cron/", 1)[1]))
         else:
             self.send_error(404, "Not Found")
 
@@ -4686,6 +4906,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._alerts_delete(urllib.parse.unquote(parsed_path.split("/v1/alerts/", 1)[1]))
         elif parsed_path.startswith("/v1/skills/"):
             self._skills_delete(urllib.parse.unquote(parsed_path.split("/v1/skills/", 1)[1]))
+        elif parsed_path.startswith("/v1/cron/"):
+            self._cron_delete(urllib.parse.unquote(parsed_path.split("/v1/cron/", 1)[1]))
         else:
             self.send_error(404, "Not Found")
 
@@ -5413,6 +5635,351 @@ class BridgeHandler(BaseHTTPRequestHandler):
             "cognition_launch_iso": _cognition_launch_iso,
         }
         self._json_response(200, status)
+
+    # ------------------------------------------------------------------
+    # Doctor — structured readiness report for all Eva subsystems
+    # ------------------------------------------------------------------
+    def _doctor(self):
+        report = {"timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(), "subsystems": {}, "readiness": {}, "blockers": []}
+
+        # ACP / Copilot CLI
+        acp_ok = bool(acp_client and acp_client.alive)
+        report["subsystems"]["acp"] = {
+            "ok": acp_ok,
+            "session_id": acp_client.session_id if acp_client else None,
+            "model": acp_client.model if acp_client else None,
+        }
+        if not acp_ok:
+            report["blockers"].append("ACP client not connected. Run: copilot auth login")
+
+        # MCP servers
+        mcp_names = list(acp_client.mcp_config.keys()) if acp_client and acp_client.mcp_config else []
+        report["subsystems"]["mcp"] = {"configured": mcp_names, "count": len(mcp_names)}
+
+        # Browser agent
+        ba_module = _BROWSER_AGENT is not None
+        ba_playwright = False
+        if ba_module:
+            try:
+                import importlib
+                importlib.import_module("playwright")
+                ba_playwright = True
+            except ImportError:
+                pass
+        report["subsystems"]["browser_agent"] = {
+            "module_loaded": ba_module,
+            "playwright_available": ba_playwright,
+        }
+        if ba_module and not ba_playwright:
+            report["blockers"].append("Playwright not installed. Run: pip install playwright && playwright install chromium")
+
+        # Desktop agent
+        da_module = _DESKTOP_AGENT is not None
+        da_pyautogui = False
+        da_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+        if da_module:
+            try:
+                import importlib
+                importlib.import_module("pyautogui")
+                da_pyautogui = True
+            except ImportError:
+                pass
+        da_ydotool = shutil.which("ydotool") is not None
+        da_computer_use = shutil.which("computer-use-linux") is not None
+        report["subsystems"]["desktop_agent"] = {
+            "module_loaded": da_module,
+            "pyautogui_available": da_pyautogui,
+            "display_available": da_display,
+            "ydotool_available": da_ydotool,
+            "computer_use_linux_available": da_computer_use,
+        }
+        if da_module and not da_display:
+            report["blockers"].append("No DISPLAY or WAYLAND_DISPLAY set. Desktop agent requires a graphical session.")
+
+        # Camera
+        cam_module = _CAMERA is not None
+        cam_cv2 = False
+        cam_device = False
+        if cam_module:
+            cam_cv2, _ = _CAMERA.opencv_available()
+            cam_status = _CAMERA.status()
+            cam_device = cam_status.get("present", False) or cam_status.get("enabled", False)
+        report["subsystems"]["camera"] = {
+            "module_loaded": cam_module,
+            "opencv_available": cam_cv2,
+            "device_present": cam_device,
+        }
+
+        # Kusto / memory
+        cluster, database = _get_kusto_config()
+        kusto_configured = bool(cluster and database)
+        kusto_token = bool(_kusto_token_cache)
+        report["subsystems"]["kusto"] = {
+            "configured": kusto_configured,
+            "cluster": cluster[:30] + "..." if cluster and len(cluster) > 30 else cluster,
+            "database": database,
+            "token_valid": kusto_token,
+        }
+        if not kusto_configured:
+            report["blockers"].append("Kusto not configured. Set up in Settings > MCP tab.")
+        elif not kusto_token:
+            report["blockers"].append("Kusto token expired or unavailable. Re-authenticate.")
+
+        # Background loop
+        bg_running = bool(_bg_loop_thread and _bg_loop_thread.is_alive())
+        report["subsystems"]["background"] = {
+            "enabled": _bg_loop_enabled,
+            "running": bg_running,
+            "interval_seconds": _bg_loop_interval_seconds,
+            "last_tick": _bg_last_tick_iso,
+        }
+
+        # Cron
+        with _cron_lock:
+            cron_count = len(_cron_tasks)
+            cron_enabled = sum(1 for t in _cron_tasks if t.get("enabled", True))
+        report["subsystems"]["cron"] = {
+            "total_tasks": cron_count,
+            "enabled_tasks": cron_enabled,
+        }
+
+        # Cognition
+        report["subsystems"]["cognition"] = {
+            "enabled": _cognition_enabled,
+            "launch_id": _cognition_launch_id,
+        }
+
+        # System
+        node_version = None
+        try:
+            node_version = subprocess.check_output(["node", "--version"], stderr=subprocess.DEVNULL, timeout=5).decode().strip()
+        except Exception:
+            pass
+        report["subsystems"]["system"] = {
+            "python": sys.version.split()[0],
+            "node": node_version,
+            "platform": platform.platform(),
+            "arch": platform.machine(),
+        }
+
+        # Readiness summary
+        report["readiness"] = {
+            "can_chat": acp_ok,
+            "can_browse": ba_module and ba_playwright,
+            "can_desktop": da_module and da_display,
+            "can_see": cam_module and cam_cv2,
+            "can_remember": kusto_configured and kusto_token,
+            "can_schedule": bg_running,
+            "can_cron": cron_enabled > 0,
+        }
+
+        self._json_response(200, report)
+
+    # ------------------------------------------------------------------
+    # Cron CRUD endpoints
+    # ------------------------------------------------------------------
+    def _cron_list(self):
+        with _cron_lock:
+            tasks = list(_cron_tasks)
+        self._json_response(200, {"tasks": tasks, "count": len(tasks)})
+
+    def _cron_create(self):
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "cron mutations restricted to loopback"}})
+            return
+        data, err = self._read_json_body()
+        if err:
+            self._json_response(400, {"error": {"message": err}})
+            return
+        label = str((data or {}).get("label", "")).strip()
+        schedule = str((data or {}).get("schedule", "")).strip()
+        prompt = str((data or {}).get("prompt", "")).strip()
+        if not label or not schedule or not prompt:
+            self._json_response(400, {"error": {"message": "label, schedule (cron expr), and prompt are required"}})
+            return
+        parsed, parse_err = _parse_cron_expr(schedule)
+        if parse_err or parsed is None:
+            self._json_response(400, {"error": {"message": f"invalid cron expression: {parse_err}"}})
+            return
+        now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        task = {
+            "id": "cron-" + uuid.uuid4().hex[:8],
+            "label": label[:120],
+            "schedule": schedule,
+            "prompt": prompt[:2000],
+            "enabled": bool((data or {}).get("enabled", True)),
+            "last_run": "",
+            "next_run": _cron_next_run(schedule) or "",
+            "created_at": now_iso,
+        }
+        with _cron_lock:
+            _cron_tasks.append(task)
+            _save_cron_tasks()
+        self._json_response(201, {"task": task})
+
+    def _cron_update(self, task_id):
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "cron mutations restricted to loopback"}})
+            return
+        data, err = self._read_json_body()
+        if err:
+            self._json_response(400, {"error": {"message": err}})
+            return
+        with _cron_lock:
+            task = next((t for t in _cron_tasks if t.get("id") == task_id), None)
+            if not task:
+                self._json_response(404, {"error": {"message": "cron task not found"}})
+                return
+            if "label" in (data or {}):
+                task["label"] = str(data["label"])[:120]
+            if "schedule" in (data or {}):
+                new_sched = str(data["schedule"]).strip()
+                parsed, parse_err = _parse_cron_expr(new_sched)
+                if parse_err or parsed is None:
+                    self._json_response(400, {"error": {"message": f"invalid cron expression: {parse_err}"}})
+                    return
+                task["schedule"] = new_sched
+                task["next_run"] = _cron_next_run(new_sched) or ""
+            if "prompt" in (data or {}):
+                task["prompt"] = str(data["prompt"])[:2000]
+            if "enabled" in (data or {}):
+                task["enabled"] = bool(data["enabled"])
+            _save_cron_tasks()
+        self._json_response(200, {"task": task})
+
+    def _cron_delete(self, task_id):
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "cron mutations restricted to loopback"}})
+            return
+        with _cron_lock:
+            before = len(_cron_tasks)
+            _cron_tasks[:] = [t for t in _cron_tasks if t.get("id") != task_id]
+            if len(_cron_tasks) == before:
+                self._json_response(404, {"error": {"message": "cron task not found"}})
+                return
+            _save_cron_tasks()
+        self._json_response(200, {"ok": True})
+
+    # ------------------------------------------------------------------
+    # Skills auto-learn — extract a skill from a successful interaction
+    # ------------------------------------------------------------------
+    def _skills_auto_learn(self):
+        """Given recent conversation context, ask the model to extract a reusable skill."""
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "auto-learn restricted to loopback"}})
+            return
+        data, err = self._read_json_body()
+        if err:
+            self._json_response(400, {"error": {"message": err}})
+            return
+        messages = (data or {}).get("messages", [])
+        task_summary = str((data or {}).get("task_summary", "")).strip()
+        if not messages and not task_summary:
+            self._json_response(400, {"error": {"message": "messages or task_summary required"}})
+            return
+
+        # Build a conversation digest for the model
+        digest_parts = []
+        if task_summary:
+            digest_parts.append(f"Task: {task_summary}")
+        for msg in messages[-20:]:
+            role = msg.get("role", "user")
+            content = str(msg.get("content", ""))[:500]
+            digest_parts.append(f"{role}: {content}")
+        digest = "\n".join(digest_parts)[:4000]
+
+        extract_prompt = (
+            "You are a skill extraction engine. Given the following successful interaction, "
+            "extract a reusable skill that Eva can apply to similar tasks in the future.\n\n"
+            "Return a JSON object with these fields:\n"
+            '- "Name": short skill name (2-5 words)\n'
+            '- "Description": one-sentence description of what this skill does\n'
+            '- "Instructions": step-by-step instructions Eva should follow (markdown)\n'
+            '- "Tools": comma-separated list of tools/capabilities used\n'
+            '- "Tags": comma-separated tags for categorization\n\n'
+            "Return ONLY the JSON object, no markdown fencing.\n\n"
+            f"Interaction:\n{digest}"
+        )
+
+        # Use ACP to generate the skill
+        if not acp_client or not acp_client.alive:
+            self._json_response(503, {"error": {"message": "ACP not available for skill extraction"}})
+            return
+
+        try:
+            result = acp_client.send_prompt([
+                {"role": "system", "content": "You extract reusable skills from successful interactions. Output only valid JSON."},
+                {"role": "user", "content": extract_prompt}
+            ])
+            # Parse the result as JSON
+            result_text = str(result or "").strip()
+            # Strip markdown fencing if present
+            if result_text.startswith("```"):
+                result_text = re.sub(r"^```(?:json)?\s*", "", result_text)
+                result_text = re.sub(r"\s*```$", "", result_text)
+            draft = json.loads(result_text)
+            draft["Source"] = "auto-learned"
+            draft["Status"] = "draft"
+            self._json_response(200, {"draft": draft})
+        except json.JSONDecodeError:
+            self._json_response(200, {"draft": None, "raw": result_text[:1000], "error": "model output was not valid JSON"})
+        except Exception as e:
+            self._json_response(502, {"error": {"message": f"skill extraction failed: {e}"}})
+
+    # ------------------------------------------------------------------
+    # Subagent parallelism
+    # ------------------------------------------------------------------
+    def _subagent_spawn(self):
+        """Spawn an isolated subagent that runs a prompt concurrently."""
+        if not _is_loopback_bind():
+            self._json_response(403, {"error": {"message": "subagent restricted to loopback"}})
+            return
+        data, err = self._read_json_body()
+        if err:
+            self._json_response(400, {"error": {"message": err}})
+            return
+        prompt = str((data or {}).get("prompt", "")).strip()
+        label = str((data or {}).get("label", "subagent task")).strip()[:120]
+        if not prompt:
+            self._json_response(400, {"error": {"message": "prompt is required"}})
+            return
+        with _subagent_lock:
+            running = sum(1 for t in _subagent_tasks.values() if t.get("status") == "running")
+            if running >= _SUBAGENT_MAX:
+                self._json_response(429, {"error": {"message": f"max {_SUBAGENT_MAX} concurrent subagents"}})
+                return
+        task_id = "sub-" + uuid.uuid4().hex[:8]
+        now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        task = {
+            "id": task_id,
+            "label": label,
+            "prompt": prompt[:500],
+            "status": "running",
+            "result": None,
+            "started_at": now_iso,
+            "ended_at": None,
+        }
+        with _subagent_lock:
+            _subagent_tasks[task_id] = task
+        thread = threading.Thread(target=_subagent_worker, args=(task_id, prompt, label), name=f"subagent-{task_id}", daemon=True)
+        thread.start()
+        self._json_response(202, {"task": {k: v for k, v in task.items() if k != "thread"}})
+
+    def _subagent_status(self):
+        """Return status of all subagent tasks, or a specific one via ?id=..."""
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        task_id = (params.get("id", [""])[0] or "").strip()
+        with _subagent_lock:
+            if task_id:
+                task = _subagent_tasks.get(task_id)
+                if not task:
+                    self._json_response(404, {"error": {"message": "subagent task not found"}})
+                    return
+                self._json_response(200, {"task": {k: v for k, v in task.items() if k != "thread"}})
+            else:
+                tasks = [{k: v for k, v in t.items() if k != "thread"} for t in _subagent_tasks.values()]
+                running = sum(1 for t in tasks if t.get("status") == "running")
+                self._json_response(200, {"tasks": tasks[-20:], "running": running, "max": _SUBAGENT_MAX})
 
     def _models(self):
         models = {
@@ -7131,6 +7698,14 @@ def main():
     print(f"  POST /v1/browser/cancel     - Cancel a browser agent run")
     print(f"  GET  /v1/files/<name>       - Download a generated artifact")
     print(f"  POST /v1/files/purge        - Delete all artifacts")
+    print(f"  GET  /v1/doctor             - Structured readiness report")
+    print(f"  GET  /v1/cron               - List cron tasks")
+    print(f"  POST /v1/cron               - Create a cron task")
+    print(f"  PATCH /v1/cron/<id>         - Update a cron task")
+    print(f"  DELETE /v1/cron/<id>        - Delete a cron task")
+    print(f"  POST /v1/skills/auto-learn  - Extract skill from interaction")
+    print(f"  POST /v1/subagent/spawn     - Spawn a parallel subagent task")
+    print(f"  GET  /v1/subagent/status    - Poll subagent task status")
     print(f"  GET  /health                - Health check")
     print()
 

--- a/tools/acp_bridge.service
+++ b/tools/acp_bridge.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Eva ACP Bridge - Copilot CLI to HTTP bridge
-Documentation=https://github.com/appatalks/chatgpt-html
+Documentation=https://github.com/appatalks/eva-agent
 After=network.target
 
 [Service]


### PR DESCRIPTION
…s, computer-use-linux MCP

Inspired by NousResearch/hermes-agent comparison. Five new subsystems:

Doctor (GET /v1/doctor): structured readiness probe for all Eva subsystems (ACP, browser, desktop, camera, Kusto, background, cron, cognition, system). Reports blockers with actionable fixes. Frontend button in Settings > General.

Cron scheduler: 5-field cron expression parser with persistent task storage (~/.config/eva-standalone/cron_tasks.json). CRUD via /v1/cron endpoints. Evaluation every minute from the background loop. New Settings > Cron tab with task form and list management.

Skills auto-learn (POST /v1/skills/auto-learn): extracts reusable skills from successful browser/desktop agent completions. Sends conversation context to ACP with an extraction prompt, stores result as a draft skill in Kusto for user review.

Subagent parallelism (POST /v1/subagent/spawn): isolated threads running prompts through ACP concurrently (up to 4). Status polling via GET /v1/subagent/status. Results delivered through notification system.

computer-use-linux MCP: new toggle in Settings > MCP tab. Configures the AT-SPI-based desktop control MCP server (Wayland-first, semantic selectors instead of pixel coordinates). Doctor probe checks binary availability.