### PR TITLE
feat: SQLite local memory backend

### DIFF
--- a/core/js/copilot.js
+++ b/core/js/copilot.js
@@ -447,15 +447,10 @@ async function autoApplySavedMCPConfig() {
           saved = restored;
           localStorage.setItem('mcp_config', JSON.stringify(saved));
           populateMCPForm(saved);
-          // localStorage was wiped (e.g. an app rebuild), so the first-run
-          // setup modal may have already popped before this async restore.
-          // Now that the saved Kusto config is back, dismiss it and mark setup
-          // done so the user is not asked to reconfigure something they have.
           try {
             var _k = restored['kusto-mcp-server'];
             if (_k && _k.env && _k.env.KUSTO_CLUSTER_URL) {
               localStorage.setItem('eva_standalone_first_run_done', '1');
-              if (typeof hideStandaloneFirstRunModal === 'function') hideStandaloneFirstRunModal();
             }
           } catch (_e) {}
         }

--- a/core/js/copilot.js
+++ b/core/js/copilot.js
@@ -783,7 +783,70 @@ document.addEventListener('DOMContentLoaded', function() {
   if (seedDatabase) seedDatabase.addEventListener('input', updateKustoSeedButtonState);
   updateKustoSeedButtonState();
 
+  // Memory backend selector
+  initMemoryBackendSelector();
+
   // Re-push saved MCP servers (Kusto cluster/db, Azure, GitHub) to the freshly
   // started bridge so they persist across restarts without manual reconfigure.
   autoApplySavedMCPConfig();
 });
+
+// ── Memory backend selector ─────────────────────────────────────────────
+function initMemoryBackendSelector() {
+  var sel = document.getElementById('memoryBackendSelect');
+  var statusEl = document.getElementById('memoryBackendStatus');
+  if (!sel) return;
+
+  // Load persisted preference
+  var saved = localStorage.getItem('eva_memory_backend');
+  if (saved && (saved === 'kusto' || saved === 'sqlite')) {
+    sel.value = saved;
+  }
+
+  // Fetch current state from bridge
+  var bridgeUrl = getACPBridgeUrl();
+  fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/memory/backend', {
+    signal: AbortSignal.timeout(3000)
+  }).then(function(r) { return r.json(); }).then(function(data) {
+    if (data.backend) {
+      sel.value = data.backend;
+      localStorage.setItem('eva_memory_backend', data.backend);
+      if (statusEl) {
+        if (data.backend === 'sqlite') {
+          statusEl.textContent = 'Active: local SQLite' + (data.db_path ? ' (' + data.db_path + ')' : '');
+        } else {
+          statusEl.textContent = 'Active: Azure Data Explorer' + (data.cluster ? ' (' + data.database + ')' : '');
+        }
+      }
+    }
+  }).catch(function() {
+    // Bridge not available — use localStorage value
+    if (statusEl) statusEl.textContent = 'Bridge not reachable — using saved preference';
+  });
+
+  sel.addEventListener('change', function() {
+    var backend = sel.value;
+    localStorage.setItem('eva_memory_backend', backend);
+    if (statusEl) statusEl.textContent = 'Switching...';
+    fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/memory/backend', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ backend: backend }),
+      signal: AbortSignal.timeout(5000)
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data.status === 'ok') {
+        if (statusEl) {
+          if (backend === 'sqlite') {
+            statusEl.textContent = 'Switched to local SQLite' + (data.db_path ? ' (' + data.db_path + ')' : '');
+          } else {
+            statusEl.textContent = 'Switched to Azure Data Explorer — configure Kusto MCP below';
+          }
+        }
+      } else {
+        if (statusEl) statusEl.textContent = 'Error: ' + JSON.stringify(data.error || data);
+      }
+    }).catch(function(e) {
+      if (statusEl) statusEl.textContent = 'Failed to switch: ' + e.message;
+    });
+  });
+}

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -1606,14 +1606,24 @@ function setStandaloneFirstRunStatus(text) {
 }
 
 function updateStandaloneFirstRunSaveState() {
+  var backendSel = document.getElementById('firstRunMemoryBackend');
   var cluster = document.getElementById('firstRunKustoCluster');
   var database = document.getElementById('firstRunKustoDatabase');
+  var kustoFields = document.getElementById('firstRunKustoFields');
   var saveButton = document.getElementById('firstRunSave');
   if (!saveButton) return;
-  saveButton.disabled = !(
-    cluster && cluster.value.trim() &&
-    database && database.value.trim()
-  );
+
+  var backend = backendSel ? backendSel.value : 'sqlite';
+  if (kustoFields) kustoFields.style.display = (backend === 'kusto') ? 'block' : 'none';
+
+  if (backend === 'sqlite') {
+    saveButton.disabled = false;
+  } else {
+    saveButton.disabled = !(
+      cluster && cluster.value.trim() &&
+      database && database.value.trim()
+    );
+  }
 }
 
 function showStandaloneFirstRunModal() {
@@ -1651,6 +1661,34 @@ function skipStandaloneFirstRun() {
 
 async function saveStandaloneFirstRunConfig() {
   if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
+  var backendSel = document.getElementById('firstRunMemoryBackend');
+  var backend = backendSel ? backendSel.value : 'sqlite';
+
+  localStorage.setItem('eva_memory_backend', backend);
+  localStorage.setItem('eva_standalone_first_run_done', '1');
+
+  if (backend === 'sqlite') {
+    // SQLite path: tell the bridge, done
+    setStandaloneFirstRunStatus('Setting up local memory...');
+    var bridgeUrl = typeof getACPBridgeUrl === 'function' ? getACPBridgeUrl() : '';
+    if (bridgeUrl) {
+      try {
+        await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/memory/backend', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ backend: 'sqlite' }),
+          signal: AbortSignal.timeout(5000)
+        });
+      } catch (e) { /* bridge not yet ready, preference is saved in localStorage */ }
+    }
+    // Update the settings panel selector
+    var memSel = document.getElementById('memoryBackendSelect');
+    if (memSel) memSel.value = 'sqlite';
+    hideStandaloneFirstRunModal();
+    return;
+  }
+
+  // Kusto path (existing behavior)
   var cluster = document.getElementById('firstRunKustoCluster');
   var database = document.getElementById('firstRunKustoDatabase');
   var clusterUrl = cluster ? cluster.value.trim() : '';
@@ -1708,8 +1746,10 @@ function initStandaloneFirstRun() {
 
   var cluster = document.getElementById('firstRunKustoCluster');
   var database = document.getElementById('firstRunKustoDatabase');
+  var backendSel = document.getElementById('firstRunMemoryBackend');
   var saveButton = document.getElementById('firstRunSave');
   var skipButton = document.getElementById('firstRunSkip');
+  if (backendSel) backendSel.addEventListener('change', updateStandaloneFirstRunSaveState);
   if (cluster) cluster.addEventListener('input', updateStandaloneFirstRunSaveState);
   if (database) database.addEventListener('input', updateStandaloneFirstRunSaveState);
   if (saveButton) saveButton.addEventListener('click', saveStandaloneFirstRunConfig);
@@ -1723,7 +1763,7 @@ function initStandaloneFirstRun() {
     }
   });
 
-  if (!hasSavedStandaloneKustoConfig() && localStorage.getItem('eva_standalone_first_run_done') !== '1') {
+  if (!hasSavedStandaloneKustoConfig() && !localStorage.getItem('eva_memory_backend') && localStorage.getItem('eva_standalone_first_run_done') !== '1') {
     showStandaloneFirstRunModal();
   }
 }

--- a/core/js/options.js
+++ b/core/js/options.js
@@ -1600,171 +1600,23 @@ function hasSavedStandaloneKustoConfig() {
   return !!(env.KUSTO_CLUSTER_URL && String(env.KUSTO_CLUSTER_URL).trim());
 }
 
-function setStandaloneFirstRunStatus(text) {
-  var status = document.getElementById('firstRunStatus');
-  if (status) status.textContent = text || '';
-}
-
-function updateStandaloneFirstRunSaveState() {
-  var backendSel = document.getElementById('firstRunMemoryBackend');
-  var cluster = document.getElementById('firstRunKustoCluster');
-  var database = document.getElementById('firstRunKustoDatabase');
-  var kustoFields = document.getElementById('firstRunKustoFields');
-  var saveButton = document.getElementById('firstRunSave');
-  if (!saveButton) return;
-
-  var backend = backendSel ? backendSel.value : 'sqlite';
-  if (kustoFields) kustoFields.style.display = (backend === 'kusto') ? 'block' : 'none';
-
-  if (backend === 'sqlite') {
-    saveButton.disabled = false;
-  } else {
-    saveButton.disabled = !(
-      cluster && cluster.value.trim() &&
-      database && database.value.trim()
-    );
-  }
-}
-
-function showStandaloneFirstRunModal() {
-  if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
-  var modal = document.getElementById('firstRunModal');
-  if (!modal) return;
-  var overlay = document.getElementById('settingsOverlay');
-  var cluster = document.getElementById('firstRunKustoCluster');
-  var database = document.getElementById('firstRunKustoDatabase');
-  if (cluster) cluster.value = '';
-  if (database) database.value = '';
-  setStandaloneFirstRunStatus('');
-  if (overlay) overlay.classList.add('open');
-  modal.style.display = 'flex';
-  updateStandaloneFirstRunSaveState();
-  setTimeout(function() {
-    if (cluster) cluster.focus();
-  }, 0);
-}
-
-function hideStandaloneFirstRunModal() {
-  var modal = document.getElementById('firstRunModal');
-  if (modal) modal.style.display = 'none';
-  var settingsMenu = document.getElementById('settingsMenu');
-  var overlay = document.getElementById('settingsOverlay');
-  if (overlay && !(settingsMenu && settingsMenu.classList.contains('open'))) {
-    overlay.classList.remove('open');
-  }
-}
-
-function skipStandaloneFirstRun() {
-  localStorage.setItem('eva_standalone_first_run_done', '1');
-  hideStandaloneFirstRunModal();
-}
-
-async function saveStandaloneFirstRunConfig() {
-  if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
-  var backendSel = document.getElementById('firstRunMemoryBackend');
-  var backend = backendSel ? backendSel.value : 'sqlite';
-
-  localStorage.setItem('eva_memory_backend', backend);
-  localStorage.setItem('eva_standalone_first_run_done', '1');
-
-  if (backend === 'sqlite') {
-    // SQLite path: tell the bridge, done
-    setStandaloneFirstRunStatus('Setting up local memory...');
-    var bridgeUrl = typeof getACPBridgeUrl === 'function' ? getACPBridgeUrl() : '';
-    if (bridgeUrl) {
-      try {
-        await fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/memory/backend', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ backend: 'sqlite' }),
-          signal: AbortSignal.timeout(5000)
-        });
-      } catch (e) { /* bridge not yet ready, preference is saved in localStorage */ }
-    }
-    // Update the settings panel selector
-    var memSel = document.getElementById('memoryBackendSelect');
-    if (memSel) memSel.value = 'sqlite';
-    hideStandaloneFirstRunModal();
-    return;
-  }
-
-  // Kusto path (existing behavior)
-  var cluster = document.getElementById('firstRunKustoCluster');
-  var database = document.getElementById('firstRunKustoDatabase');
-  var clusterUrl = cluster ? cluster.value.trim() : '';
-  var databaseName = database ? database.value.trim() : '';
-  if (!clusterUrl || !databaseName) return;
-
-  var config = getSavedMCPConfig();
-  config['kusto-mcp-server'] = {
-    command: 'python3',
-    args: ['tools/kusto_mcp.py'],
-    env: {
-      KUSTO_CLUSTER_URL: clusterUrl,
-      KUSTO_DATABASE: databaseName,
-      KUSTO_DATABASE_LOCKED: '1'
-    }
-  };
-  localStorage.setItem('mcp_config', JSON.stringify(config));
-  localStorage.setItem('eva_standalone_first_run_done', '1');
-
-  var kustoCheck = document.getElementById('mcpKusto');
-  var kustoConfig = document.getElementById('mcpKustoConfig');
-  var clusterField = document.getElementById('mcpKustoCluster');
-  var databaseField = document.getElementById('mcpKustoDatabase');
-  if (kustoCheck) kustoCheck.checked = true;
-  if (kustoConfig) kustoConfig.style.display = 'block';
-  if (clusterField) clusterField.value = clusterUrl;
-  if (databaseField) databaseField.value = databaseName;
-  if (typeof updateKustoSeedButtonState === 'function') updateKustoSeedButtonState();
-
-  setStandaloneFirstRunStatus('Configuring Kusto MCP...');
-  var result = { ok: false };
-  if (typeof applyMCPConfig === 'function') {
-    result = await applyMCPConfig();
-  }
-  hideStandaloneFirstRunModal();
-
-  if (result && result.ok) {
-    var shouldSeed = confirm('Seed Eva schema into ' + databaseName + '?');
-    if (shouldSeed && typeof seedEvaSchema === 'function') {
-      await seedEvaSchema(clusterUrl, databaseName, true);
-    }
-  }
-}
-
 function initStandaloneFirstRun() {
   if (!(typeof isEvaStandalone === 'function' && isEvaStandalone())) return;
-  var rerunButton = document.getElementById('standaloneFirstRunButton');
-  if (rerunButton) {
-    rerunButton.style.display = 'block';
-    rerunButton.addEventListener('click', function() {
-      localStorage.removeItem('eva_standalone_first_run_done');
-      showStandaloneFirstRunModal();
-    });
-  }
-
-  var cluster = document.getElementById('firstRunKustoCluster');
-  var database = document.getElementById('firstRunKustoDatabase');
-  var backendSel = document.getElementById('firstRunMemoryBackend');
-  var saveButton = document.getElementById('firstRunSave');
-  var skipButton = document.getElementById('firstRunSkip');
-  if (backendSel) backendSel.addEventListener('change', updateStandaloneFirstRunSaveState);
-  if (cluster) cluster.addEventListener('input', updateStandaloneFirstRunSaveState);
-  if (database) database.addEventListener('input', updateStandaloneFirstRunSaveState);
-  if (saveButton) saveButton.addEventListener('click', saveStandaloneFirstRunConfig);
-  if (skipButton) {
-    skipButton.addEventListener('click', skipStandaloneFirstRun);
-  }
-  document.addEventListener('keydown', function(event) {
-    var modal = document.getElementById('firstRunModal');
-    if (event.key === 'Escape' && modal && modal.style.display !== 'none') {
-      skipStandaloneFirstRun();
+  // If no memory backend has been chosen yet, default to SQLite and seed
+  if (!localStorage.getItem('eva_memory_backend') && !hasSavedStandaloneKustoConfig()) {
+    localStorage.setItem('eva_memory_backend', 'sqlite');
+    localStorage.setItem('eva_standalone_first_run_done', '1');
+    var bridgeUrl = typeof getACPBridgeUrl === 'function' ? getACPBridgeUrl() : '';
+    if (bridgeUrl) {
+      fetch(bridgeUrl.replace(/\/+$/, '') + '/v1/memory/backend', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ backend: 'sqlite' }),
+        signal: AbortSignal.timeout(5000)
+      }).catch(function() {});
     }
-  });
-
-  if (!hasSavedStandaloneKustoConfig() && !localStorage.getItem('eva_memory_backend') && localStorage.getItem('eva_standalone_first_run_done') !== '1') {
-    showStandaloneFirstRunModal();
+    var memSel = document.getElementById('memoryBackendSelect');
+    if (memSel) memSel.value = 'sqlite';
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
         <hr style="margin:14px 0;border:none;border-top:1px solid rgba(127,127,127,0.25)">
         <div class="auth-note" style="margin:0">
           <strong>About</strong><br>
-          Eva AI Assistant <span id="evaAppVersion">v5.2.3</span><br>
+          Eva AI Assistant <span id="evaAppVersion">v5.3.0</span><br>
           <span>Active goals: <span id="evaActiveGoalsCount">0</span></span><br>
           <span id="evaStandaloneVersion" style="display:none"></span>
         </div>

--- a/index.html
+++ b/index.html
@@ -732,6 +732,17 @@
 
       <!-- MCP Tab -->
       <div class="settings-panel" data-stab="mcp">
+        <h4 class="settings-subhead">Memory Backend</h4>
+        <p class="auth-note">Choose where Eva stores persistent memory (knowledge, conversations, emotions, reflections).</p>
+        <div class="auth-field">
+          <select id="memoryBackendSelect" style="width:100%">
+            <option value="sqlite">Local (SQLite) — no cloud, zero setup</option>
+            <option value="kusto">Azure Data Explorer (Kusto) — cloud, cross-device</option>
+          </select>
+          <div id="memoryBackendStatus" class="mcp-status" aria-live="polite" style="margin-top:6px"></div>
+        </div>
+
+        <h4 class="settings-subhead" style="margin-top:18px">MCP Servers</h4>
         <p class="auth-note">MCP (Model Context Protocol) servers extend the AI with tools for Azure, GitHub, and more. Requires the ACP bridge (<code>tools/acp_bridge.py</code>).</p>
 
         <div class="mcp-preset">
@@ -801,12 +812,24 @@
       <h3 id="firstRunModalTitle">Set Up Eva Memory</h3>
     </div>
     <div class="settings-body">
-      <p class="auth-note">Choose the Azure Data Explorer database Eva should use for memory.</p>
+      <p class="auth-note">Choose where Eva stores persistent memory.</p>
       <div class="auth-field">
-        <label for="firstRunKustoCluster">Cluster URL:</label>
-        <input type="text" id="firstRunKustoCluster" placeholder="https://kvc-xxx.region.kusto.windows.net" autocomplete="off">
+        <label for="firstRunMemoryBackend">Memory backend:</label>
+        <select id="firstRunMemoryBackend">
+          <option value="sqlite" selected>Local (SQLite) — no cloud, works offline</option>
+          <option value="kusto">Azure Data Explorer (Kusto) — cloud, cross-device</option>
+        </select>
       </div>
-      <div class="auth-field">
+      <div id="firstRunKustoFields" style="display:none">
+        <div class="auth-field">
+          <label for="firstRunKustoCluster">Cluster URL:</label>
+          <input type="text" id="firstRunKustoCluster" placeholder="https://kvc-xxx.region.kusto.windows.net" autocomplete="off">
+        </div>
+        <div class="auth-field">
+          <label for="firstRunKustoDatabase">Database name:</label>
+          <input type="text" id="firstRunKustoDatabase" placeholder="eva-standalone" autocomplete="off">
+        </div>
+      </div>
         <label for="firstRunKustoDatabase">Database name:</label>
         <input type="text" id="firstRunKustoDatabase" placeholder="eva-standalone" autocomplete="off">
       </div>

--- a/index.html
+++ b/index.html
@@ -793,7 +793,6 @@
         <div id="mcpStatus" class="mcp-status"></div>
 
         <button type="button" class="auth-save" onclick="applyMCPConfig()">Apply MCP Config</button>
-        <button type="button" id="standaloneFirstRunButton" class="auth-toggle" style="display:none;margin-top:8px;width:100%;text-align:center">Run first-time setup again</button>
         <button type="button" class="auth-toggle" onclick="refreshMCPStatus()" style="margin-top:8px;width:100%;text-align:center">Refresh Status</button>
 
         <div class="mcp-preset" style="margin-top:12px">
@@ -804,38 +803,6 @@
         </div>
       </div>
 
-    </div>
-  </div>
-
-  <div class="settingsMenu" id="firstRunModal" role="dialog" aria-modal="true" aria-labelledby="firstRunModalTitle" style="display:none;position:fixed;top:50%;left:50%;transform:translate(-50%, -50%);width:500px;max-width:95vw;max-height:85vh;background:#fff;border-radius:12px;box-shadow:0 8px 32px rgba(0,0,0,0.3);z-index:10000;overflow:hidden;flex-direction:column;color:#333;">
-    <div class="settings-header">
-      <h3 id="firstRunModalTitle">Set Up Eva Memory</h3>
-    </div>
-    <div class="settings-body">
-      <p class="auth-note">Choose where Eva stores persistent memory.</p>
-      <div class="auth-field">
-        <label for="firstRunMemoryBackend">Memory backend:</label>
-        <select id="firstRunMemoryBackend">
-          <option value="sqlite" selected>Local (SQLite) — no cloud, works offline</option>
-          <option value="kusto">Azure Data Explorer (Kusto) — cloud, cross-device</option>
-        </select>
-      </div>
-      <div id="firstRunKustoFields" style="display:none">
-        <div class="auth-field">
-          <label for="firstRunKustoCluster">Cluster URL:</label>
-          <input type="text" id="firstRunKustoCluster" placeholder="https://kvc-xxx.region.kusto.windows.net" autocomplete="off">
-        </div>
-        <div class="auth-field">
-          <label for="firstRunKustoDatabase">Database name:</label>
-          <input type="text" id="firstRunKustoDatabase" placeholder="eva-standalone" autocomplete="off">
-        </div>
-      </div>
-        <label for="firstRunKustoDatabase">Database name:</label>
-        <input type="text" id="firstRunKustoDatabase" placeholder="eva-standalone" autocomplete="off">
-      </div>
-      <div id="firstRunStatus" class="mcp-status" aria-live="polite"></div>
-      <button type="button" class="auth-save" id="firstRunSave" disabled>Save and continue</button>
-      <button type="button" class="auth-toggle" id="firstRunSkip" style="margin-top:8px;width:100%;text-align:center">Skip for now</button>
     </div>
   </div>
 

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eva-standalone",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eva-standalone",
-      "version": "5.2.3",
+      "version": "5.3.0",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.8.1",

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eva-standalone",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "description": "Localhost Electron shell for Eva AI Assistant.",
   "main": "main.js",
   "private": true,

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -44,6 +44,8 @@
           "tools/desktop_agent.py",
           "tools/camera_sense.py",
           "tools/kusto_mcp.py",
+          "tools/sqlite_memory.py",
+          "tools/sqlite_mcp.py",
           "tools/eva_seed.kql",
           "!config.json",
           "!config.local.js",

--- a/tools/acp_bridge.py
+++ b/tools/acp_bridge.py
@@ -734,6 +734,53 @@ _embedding_disabled_logged = False
 _SEMANTIC_MIN_SCORE = 0.30  # cosine threshold for a fact to count as relevant
 _SEMANTIC_POOL_SIZE = 150   # max facts ranked per recall (Knowledge is small)
 
+# ── Memory backend selection ───────────────────────────────────────────────
+# "kusto" = Azure Data Explorer (default, existing behavior)
+# "sqlite" = local SQLite file via tools/sqlite_memory.py
+_memory_backend = os.environ.get("EVA_MEMORY_BACKEND", "").strip().lower() or "kusto"
+_sqlite_mem = None  # SqliteMemory instance, created lazily when backend == "sqlite"
+_MEMORY_BACKEND_PREF_PATH = os.path.expanduser("~/.config/eva-standalone/memory_backend.txt")
+
+def _resolve_memory_backend():
+    """Return the active memory backend name, checking persisted preference."""
+    global _memory_backend
+    if _memory_backend not in ("kusto", "sqlite"):
+        # Check persisted preference
+        try:
+            if os.path.isfile(_MEMORY_BACKEND_PREF_PATH):
+                with open(_MEMORY_BACKEND_PREF_PATH) as f:
+                    saved = f.read().strip().lower()
+                if saved in ("kusto", "sqlite"):
+                    _memory_backend = saved
+        except Exception:
+            pass
+    return _memory_backend
+
+def _get_sqlite_mem():
+    """Return the global SqliteMemory instance, creating it on first use."""
+    global _sqlite_mem
+    if _sqlite_mem is None:
+        from sqlite_memory import SqliteMemory
+        db_path = os.environ.get("EVA_MEMORY_DB", os.path.expanduser("~/.eva/memory.db"))
+        _sqlite_mem = SqliteMemory(db_path)
+        print(f"[Bridge] SQLite memory initialized: {_sqlite_mem.db_path}")
+    return _sqlite_mem
+
+def _set_memory_backend(backend):
+    """Switch the active memory backend and persist the choice."""
+    global _memory_backend
+    if backend not in ("kusto", "sqlite"):
+        return False
+    _memory_backend = backend
+    try:
+        os.makedirs(os.path.dirname(_MEMORY_BACKEND_PREF_PATH), exist_ok=True)
+        with open(_MEMORY_BACKEND_PREF_PATH, "w") as f:
+            f.write(backend)
+    except Exception as e:
+        print(f"[Bridge] Failed to persist memory backend preference: {e}")
+    print(f"[Bridge] Memory backend set to: {backend}")
+    return True
+
 # Synonyms expand a query term so lexical recall matches differently-worded facts
 # (e.g. "playlist" should surface a fact stored under relation "favorite_songs").
 _MEMORY_SYNONYMS = {
@@ -2500,6 +2547,75 @@ def _kusto_ingest_direct(cluster_url, database, table, columns, rows_data):
             print(f"[Cognition] Kusto ingest error: {e}")
             return False
 
+# ---------------------------------------------------------------------------
+# Memory routing — dispatches to Kusto or SQLite based on _memory_backend
+# ---------------------------------------------------------------------------
+
+def _memory_query(query_or_table, cluster_url=None, database=None, is_mgmt=False):
+    """Backend-agnostic query. For Kusto, pass cluster_url/database and a KQL query.
+    For SQLite, pass a SQL query (KQL management queries return sensible defaults).
+    Returns list of dicts (same format as _kusto_query_direct)."""
+    backend = _resolve_memory_backend()
+    if backend == "sqlite":
+        mem = _get_sqlite_mem()
+        q = query_or_table.strip()
+        # Handle Kusto management commands that the bridge uses
+        if q.startswith(".show databases"):
+            return [{"DatabaseName": "local", "path": mem.db_path}]
+        if q.startswith(".show tables"):
+            return [{"TableName": t} for t in mem.list_tables()]
+        if q.startswith(".show table") and "cslschema" in q:
+            # Extract table name from ".show table X cslschema"
+            parts = q.split()
+            tname = parts[2] if len(parts) > 2 else ""
+            schema = mem.get_schema(tname)
+            if not schema:
+                return []
+            schema_str = ", ".join(f"{c}:{t}" for c, t in schema)
+            return [{"Schema": schema_str}]
+        # Regular SQL query
+        return mem.query(q) or []
+    else:
+        if not cluster_url:
+            cluster_url, database = _get_kusto_config()
+        if not cluster_url:
+            return []
+        return _kusto_query_direct(cluster_url, database, query_or_table, is_mgmt=is_mgmt) or []
+
+
+def _memory_ingest(table, columns, rows_data, cluster_url=None, database=None):
+    """Backend-agnostic ingest. Same signature as _kusto_ingest_direct."""
+    backend = _resolve_memory_backend()
+    if backend == "sqlite":
+        mem = _get_sqlite_mem()
+        return mem.ingest(table, columns, rows_data)
+    else:
+        if not cluster_url:
+            cluster_url, database = _get_kusto_config()
+        if not cluster_url:
+            return False
+        return _kusto_ingest_direct(cluster_url, database, table, columns, rows_data)
+
+
+def _memory_fts_search(terms, limit=20):
+    """Full-text search on Knowledge table. Only meaningful for SQLite backend;
+    Kusto backend falls back to the existing lexical/semantic recall pipeline."""
+    backend = _resolve_memory_backend()
+    if backend == "sqlite":
+        mem = _get_sqlite_mem()
+        return mem.fts_search("Knowledge", terms, limit=limit)
+    return []
+
+
+def _memory_available():
+    """Check whether the memory backend is configured and reachable."""
+    backend = _resolve_memory_backend()
+    if backend == "sqlite":
+        return True  # SQLite is always available (file is created on demand)
+    else:
+        cluster, db = _get_kusto_config()
+        return bool(cluster and db and _kusto_token_cache)
+
 def _get_kusto_config():
     """Get Kusto cluster URL and database from the running MCP config."""
     if not acp_client or not acp_client.mcp_config:
@@ -2525,36 +2641,49 @@ def _enable_cognition(mcp_servers, model=None, port=None):
     _cognition_launch_iso = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
     _cognition_launch_id = f"eva-{datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d%H%M%S')}"
     _cognition_enabled = True
-    print(f"[Bridge] Cognition layer ENABLED (memory injection + reflection)")
+    backend = _resolve_memory_backend()
+    print(f"[Bridge] Cognition layer ENABLED (memory backend: {backend})")
     print(f"[Bridge] Cognition launch scope: {_cognition_launch_id} (since {_cognition_launch_iso})")
 
-    cluster, startup_db = _get_kusto_config()
-    if cluster and startup_db:
-        now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
-        selfstate_cols = ["Timestamp", "Capability", "Status", "Details"]
-        capabilities = [
-            {"Timestamp": now, "Capability": "kusto_access", "Status": "active",
-             "Details": json.dumps({"cluster": cluster, "database": startup_db})},
-            {"Timestamp": now, "Capability": "acp_bridge", "Status": "active",
-             "Details": json.dumps({"model": model or "default", "port": port})},
-            {"Timestamp": now, "Capability": "cognition", "Status": "active",
-             "Details": json.dumps({"features": ["memory_injection", "reflection", "day_lifecycle", "emotion_tracking"]})},
-            {"Timestamp": now, "Capability": "data_retrieval", "Status": "active",
-             "Details": json.dumps({"skills": ["stock_quotes", "financial_data", "company_info", "web_search"]})},
-            {"Timestamp": now, "Capability": "weather_news", "Status": "active",
-             "Details": json.dumps({"feeds": ["weather", "news", "markets", "space_weather"]})},
-            {"Timestamp": now, "Capability": "image_skills", "Status": "active",
-             "Details": json.dumps({"skills": ["wikimedia_search", "dalle3_generation"]})},
-            {"Timestamp": now, "Capability": "persistent_memory", "Status": "active",
-                    "Details": json.dumps({"tables": _MEMORY_TABLES})},
-        ]
-        for srv in mcp_servers.keys():
-            capabilities.append({"Timestamp": now, "Capability": f"mcp_{srv}",
-                                 "Status": "active", "Details": "{}"})
-        if _kusto_ingest_direct(cluster, startup_db, "SelfState", selfstate_cols, capabilities):
-            print(f"[Bridge] SelfState written ({len(capabilities)} capabilities)")
-        else:
-            print("[Bridge] SelfState write failed (continuing startup)")
+    # Write SelfState capabilities via the active memory backend
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    selfstate_cols = ["Timestamp", "Capability", "Status", "Details"]
+
+    if backend == "sqlite":
+        mem = _get_sqlite_mem()
+        details_mem = {"backend": "sqlite", "path": mem.db_path}
+    else:
+        cluster, startup_db = _get_kusto_config()
+        details_mem = {"cluster": cluster or "", "database": startup_db or ""}
+        if not cluster or not startup_db:
+            print("[Bridge] Kusto not configured; SelfState write skipped")
+            if _bg_loop_enabled:
+                _start_bg_loop()
+            return
+
+    capabilities = [
+        {"Timestamp": now, "Capability": "memory_access", "Status": "active",
+         "Details": json.dumps(details_mem)},
+        {"Timestamp": now, "Capability": "acp_bridge", "Status": "active",
+         "Details": json.dumps({"model": model or "default", "port": port})},
+        {"Timestamp": now, "Capability": "cognition", "Status": "active",
+         "Details": json.dumps({"features": ["memory_injection", "reflection", "day_lifecycle", "emotion_tracking"]})},
+        {"Timestamp": now, "Capability": "data_retrieval", "Status": "active",
+         "Details": json.dumps({"skills": ["stock_quotes", "financial_data", "company_info", "web_search"]})},
+        {"Timestamp": now, "Capability": "weather_news", "Status": "active",
+         "Details": json.dumps({"feeds": ["weather", "news", "markets", "space_weather"]})},
+        {"Timestamp": now, "Capability": "image_skills", "Status": "active",
+         "Details": json.dumps({"skills": ["wikimedia_search", "dalle3_generation"]})},
+        {"Timestamp": now, "Capability": "persistent_memory", "Status": "active",
+                "Details": json.dumps({"tables": _MEMORY_TABLES})},
+    ]
+    for srv in mcp_servers.keys():
+        capabilities.append({"Timestamp": now, "Capability": f"mcp_{srv}",
+                             "Status": "active", "Details": "{}"})
+    if _memory_ingest("SelfState", selfstate_cols, capabilities):
+        print(f"[Bridge] SelfState written ({len(capabilities)} capabilities)")
+    else:
+        print("[Bridge] SelfState write failed (continuing startup)")
     if _bg_loop_enabled:
         _start_bg_loop()
 
@@ -2948,6 +3077,365 @@ def _extract_entity_candidates(user_message):
 
     return accepted, rejected
 
+# ---------------------------------------------------------------------------
+# SQLite implementations of memory context + reflection
+# ---------------------------------------------------------------------------
+
+def _build_memory_context_sqlite(user_message):
+    """SQLite equivalent of _build_memory_context. Same output structure, SQL queries."""
+    global _last_interaction_date
+    import datetime
+
+    mem = _get_sqlite_mem()
+    context_parts = []
+
+    # User profile
+    user_profile = mem.query(
+        "SELECT Relation, Value, Confidence FROM Knowledge "
+        "WHERE Entity = 'User' COLLATE NOCASE AND Confidence >= 0.5 "
+        "GROUP BY Relation HAVING MAX(Timestamp) "
+        "ORDER BY Confidence DESC LIMIT 30"
+    )
+    if user_profile:
+        profile_lines = [f"- {r.get('Relation','?')}: {r.get('Value','?')}" for r in user_profile]
+        context_parts.append("[User Profile]\n" + "\n".join(profile_lines))
+
+    # Timestamp and skills manifest
+    _now_utc = datetime.datetime.now(datetime.timezone.utc)
+    _today_str = _now_utc.strftime("%A, %B %d, %Y")
+    _time_str = _now_utc.strftime("%H:%M UTC")
+    db_label = "local SQLite"
+    context_parts.append(
+        f"[Current Date & Time] {_today_str} — {_time_str}\n\n"
+        "[Skills]\n"
+        "You have these active capabilities. Use them proactively.\n"
+        "• data-retrieval: Fetch live stock quotes, financial data, company info via web tools (MCP)\n"
+        "• weather-news: Real-time weather, news headlines, market summaries, space weather via MCP tools\n"
+        "• image-search: Find images on Wikimedia Commons for any topic\n"
+        "• image-generation: Generate images via DALL-E 3 (use [Image of <description>] syntax)\n"
+        f"• persistent-memory: Read/write your {db_label} database. Tables:\n"
+        "    Knowledge (Entity, Relation, Value, Confidence) — facts about the user and world\n"
+        "    Conversations (SessionId, Role, Content) — chat history\n"
+        "    EmotionState (Joy, Curiosity, Concern, Trigger) — your emotional readings\n"
+        "    MemorySummaries (Period, Summary) — compressed session summaries\n"
+        "    Reflections (Timestamp, Trigger, Observation, ActionTaken, Effectiveness) — your self-reflections\n"
+        "    Goals (GoalId, Title, Status, Priority) - persistent intentions\n"
+        "    SelfState (Capability, Status) — your active capabilities\n"
+        "    HeuristicsIndex (Entity, Category, Frequency) — pattern tracking\n"
+        "    EmotionBaseline (Dimension, Value) — emotional defaults\n"
+        "    BackgroundProposals (ProposalId, Status, Payload) - human-reviewed memory proposals\n"
+        "    BackgroundActivity (TickId, Status, ProposalCount) - background loop activity\n"
+        "• memory-query: Execute SQL queries against the local Eva database\n"
+        "• web-search: Search the web and retrieve current information via MCP tools\n"
+        "\n"
+        "[Workflow: Data Requests]\n"
+        "When asked for live data (stocks, prices, company info, statistics):\n"
+        "1. Use your web/data-retrieval tools immediately — do NOT say you lack access\n"
+        "2. Present results clearly with relevant metrics\n"
+        "3. Add personal context from memory if relevant (e.g. user's location)\n"
+        "\n"
+        "[Workflow: News & Weather]\n"
+        "When asked about news, weather, or current events:\n"
+        "1. ALWAYS use your MCP web-search tools to fetch real, current data\n"
+        "2. NEVER fabricate or guess headlines, forecasts, or events\n"
+        "3. If tools are unavailable, say so honestly — do not invent content\n"
+        "\n"
+        "[Workflow: Memory]\n"
+        "When asked about what you know/remember:\n"
+        "1. Check the [Memory] facts provided below\n"
+        "2. For deeper queries, use the memory query tool on the Knowledge or Conversations table\n"
+        "3. Be specific — cite what you actually remember, not generic statements\n"
+        "\n"
+        "[Workflow: Capturing Knowledge]\n"
+        "You learn continuously. When the user shares a durable fact about themselves "
+        "(preferences, plans, relationships, possessions, lists like a playlist), or explicitly "
+        "asks you to remember/save something, persist it using the ingest tool.\n"
+        "1. Call kusto_ingest_inline with table=\"Knowledge\" and a data row per fact.\n"
+        "2. Each row must use these columns: Timestamp (current UTC ISO-8601), Entity, Relation, "
+        "Value, Confidence, Source, Decay.\n"
+        "   • Entity: use \"User\" for facts about the user; otherwise the proper-noun subject.\n"
+        "   • Relation: a short snake_case key.\n"
+        "   • Value: the concrete content.\n"
+        "   • Confidence: 0.85 when the user stated it directly; Source: \"learned\"; Decay: 0.01.\n"
+        "3. Split distinct facts into separate rows. Do NOT save ephemeral chit-chat.\n"
+        "4. After saving, briefly confirm what you stored.\n"
+        "5. Recall works only for Entity=\"User\" facts at Confidence >= 0.5 or other entities at "
+        "Confidence >= 0.6."
+    )
+
+    # Day lifecycle
+    today = datetime.date.today().isoformat()
+    if _last_interaction_date != today:
+        _last_interaction_date = today
+        summaries = mem.query(
+            "SELECT Period, Summary FROM MemorySummaries ORDER BY Timestamp DESC LIMIT 3"
+        )
+        if summaries:
+            summary_text = "\n".join(f"  - [{s.get('Period','?')}] {s.get('Summary','')}" for s in summaries[:3])
+            context_parts.append(f"[Morning Reflection — {today}]\n{summary_text}")
+        else:
+            context_parts.append(f"[Morning Reflection — {today}]\nNew day. No prior summaries.")
+
+    # Core knowledge (non-User entities)
+    knowledge_empty = not bool(user_profile)
+    core_knowledge = mem.query(
+        "SELECT Entity, Relation, Value, Confidence FROM Knowledge "
+        "WHERE Entity != 'User' COLLATE NOCASE AND Confidence >= 0.6 "
+        "AND (Relation IS NULL OR (Relation != 'mentioned' AND Relation != 'candidate_mentioned')) "
+        "ORDER BY Confidence DESC LIMIT 15"
+    )
+    if core_knowledge:
+        knowledge_empty = False
+        mem_lines = [f"  {k.get('Entity','?')} — {k.get('Relation','?')}: {k.get('Value','?')}"
+                     for k in core_knowledge]
+        context_parts.append("[Memory — Core Facts]\n" + "\n".join(mem_lines))
+
+    # Goals
+    if mem.table_exists("Goals"):
+        goals = mem.query(
+            "SELECT * FROM Goals WHERE Status = 'active' "
+            "ORDER BY Priority DESC, UpdatedAt DESC LIMIT 10"
+        )
+        if goals:
+            goal_lines = [f"  [{g.get('Category','?')}] {g.get('Title','?')}: {g.get('Description','?')}" for g in goals]
+            context_parts.append("[Active Goals]\nThese are your persistent intentions. Honor them across sessions.\n" + "\n".join(goal_lines))
+
+    # Skills (semantic match)
+    if user_message.strip() and mem.table_exists("Skills"):
+        active_skills = mem.query("SELECT * FROM Skills WHERE Status = 'active'") or []
+        if active_skills:
+            chosen = []
+            descs = [str(s.get("Description", "") or s.get("Name", "")).strip() for s in active_skills]
+            emb_map = _embed_texts([user_message] + descs)
+            qvec = emb_map.get(user_message.strip())
+            if qvec:
+                scored = []
+                for sk, d in zip(active_skills, descs):
+                    fv = emb_map.get(d.strip())
+                    if fv:
+                        scored.append((_cosine_similarity(qvec, fv), sk))
+                scored.sort(key=lambda x: x[0], reverse=True)
+                chosen = [sk for score, sk in scored[:_SKILL_INJECT_MAX] if score >= _SEMANTIC_MIN_SCORE]
+            if not chosen:
+                terms = _expand_query_terms(user_message)
+                if terms:
+                    for sk in active_skills:
+                        hay = (str(sk.get("Name","")) + " " + str(sk.get("Description",""))
+                               + " " + str(sk.get("Tags",""))).lower()
+                        if any(t in hay for t in terms):
+                            chosen.append(sk)
+                        if len(chosen) >= _SKILL_INJECT_MAX:
+                            break
+            for sk in chosen:
+                name = str(sk.get("Name", "?"))
+                instr = str(sk.get("Instructions", "")).strip()[:_SKILL_INSTRUCTIONS_INJECT_CAP]
+                tools = str(sk.get("Tools", "")).strip()
+                head = f"[Active Skill: {name}]\nThis imported skill is relevant to the request. Follow it to help the user."
+                if tools:
+                    head += f" (Uses: {tools}.)"
+                context_parts.append(head + "\n" + instr)
+
+    # Init conversation check
+    if knowledge_empty:
+        total_rows = mem.count("Knowledge")
+        if total_rows < 5:
+            context_parts.append(
+                "[Init — First Conversation]\n"
+                "Your memory is empty. This is your very first conversation.\n"
+                "Warmly introduce yourself as Eva. Then ask the user these questions naturally "
+                "(not all at once — weave them into conversation):\n"
+                "  1. What is your name?\n"
+                "  2. Where are you located?\n"
+                "  3. What topics interest you most?\n"
+                "  4. Is there anything specific you'd like me to remember about you?\n"
+                "Once the user answers, confirm what you've learned."
+            )
+
+    # Emotion state
+    emotion = mem.query("SELECT * FROM EmotionState ORDER BY Timestamp DESC LIMIT 1")
+    if emotion:
+        e = emotion[0]
+        context_parts.append(
+            f"[Emotion State] Joy:{e.get('Joy',0):.2f} Curiosity:{e.get('Curiosity',0):.2f} "
+            f"Concern:{e.get('Concern',0):.2f} Excitement:{e.get('Excitement',0):.2f} "
+            f"Calm:{e.get('Calm',0):.2f} Empathy:{e.get('Empathy',0):.2f}")
+
+    # Message-relevant knowledge (FTS + semantic)
+    relevant_hits = []
+    seen_keys = set()
+
+    def _add_hit(rec):
+        key = (str(rec.get('Entity','')).lower(), str(rec.get('Relation','')).lower(),
+               str(rec.get('Value','')).lower())
+        if key in seen_keys:
+            return
+        seen_keys.add(key)
+        relevant_hits.append(rec)
+
+    terms = _expand_query_terms(user_message)
+    if terms:
+        # FTS search
+        fts_results = mem.fts_search("Knowledge", " ".join(terms), limit=8)
+        for k in (fts_results or []):
+            if k.get("Confidence", 0) >= 0.6:
+                _add_hit(k)
+
+    if user_message.strip():
+        pool = mem.query(
+            "SELECT Entity, Relation, Value, Confidence FROM Knowledge "
+            "WHERE Confidence >= 0.6 AND (Relation IS NULL OR "
+            "(Relation != 'mentioned' AND Relation != 'candidate_mentioned')) "
+            f"ORDER BY Confidence DESC LIMIT {_SEMANTIC_POOL_SIZE}"
+        ) or []
+        if pool:
+            texts = [
+                f"{k.get('Entity','')} {str(k.get('Relation','')).replace('_',' ')} {k.get('Value','')}".strip()
+                for k in pool
+            ]
+            emb_map = _embed_texts([user_message] + texts)
+            query_vec = emb_map.get(user_message.strip())
+            if query_vec:
+                scored = []
+                for rec, txt in zip(pool, texts):
+                    fv = emb_map.get(txt.strip())
+                    if fv:
+                        scored.append((_cosine_similarity(query_vec, fv), rec))
+                scored.sort(key=lambda x: x[0], reverse=True)
+                for score, rec in scored[:6]:
+                    if score >= _SEMANTIC_MIN_SCORE:
+                        _add_hit(rec)
+
+    if relevant_hits:
+        extra = [f"  {k.get('Entity','?')} — {k.get('Relation','?')}: {k.get('Value','?')}"
+                 for k in relevant_hits]
+        context_parts.append("[Memory — Relevant to This Message]\n" + "\n".join(extra))
+
+    return "\n\n".join(context_parts)
+
+
+def _post_response_reflection_sqlite(user_message, assistant_response, model_name):
+    """SQLite equivalent of _post_response_reflection. Same write pattern, SQL instead of KQL."""
+    global _session_exchange_count, _session_conversation_buffer
+    import datetime, uuid
+
+    mem = _get_sqlite_mem()
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    session_id = str(uuid.uuid4())[:8]
+    source_id = f"{_cognition_launch_id or 'launch'}:{session_id}"
+
+    # 1. Log conversation
+    conv_columns = ["SessionId", "Timestamp", "Role", "Provider", "Model", "Content", "TokenEstimate", "ImageGenerated"]
+    conv_rows = [
+        {"SessionId": session_id, "Timestamp": now, "Role": "user", "Provider": "copilot-acp",
+         "Model": model_name, "Content": user_message[:_CONVO_CONTENT_CAP],
+         "TokenEstimate": len(user_message.split()), "ImageGenerated": 0},
+        {"SessionId": session_id, "Timestamp": now, "Role": "assistant", "Provider": "copilot-acp",
+         "Model": model_name, "Content": assistant_response[:_CONVO_CONTENT_CAP],
+         "TokenEstimate": len(assistant_response.split()), "ImageGenerated": 0},
+    ]
+    mem.ingest("Conversations", conv_columns, conv_rows)
+    print(f"[Cognition/SQLite] Logged conversation ({len(user_message)} -> {len(assistant_response)} chars)")
+
+    # 2. Extract explicit user facts
+    explicit_user_facts = _extract_explicit_user_facts(user_message)
+    if explicit_user_facts:
+        know_columns = ["Timestamp", "Entity", "Relation", "Value", "Confidence", "Source", "Decay"]
+        rows = []
+        for fact in explicit_user_facts:
+            rows.append({
+                "Timestamp": now, "Entity": fact["Entity"], "Relation": fact["Relation"],
+                "Value": fact["Value"][:200], "Confidence": fact["Confidence"],
+                "Source": source_id, "Decay": 0.005,
+            })
+        if rows and mem.ingest("Knowledge", know_columns, rows):
+            print(f"[Cognition/SQLite] Explicit user facts: {len(rows)}")
+
+    # 3. Candidate entities
+    candidate_entities, rejected_entities = _extract_entity_candidates(user_message)
+    if candidate_entities:
+        know_columns = ["Timestamp", "Entity", "Relation", "Value", "Confidence", "Source", "Decay"]
+        know_rows = []
+        for entity in candidate_entities[:3]:
+            relation, confidence, value = _classify_entity_candidate(entity, user_message)
+            if _explicit_user_fact_covers_candidate(relation, entity, explicit_user_facts):
+                relation, confidence, value = "candidate_mentioned", 0.2, "candidate extracted from conversation"
+            promotion = None
+            if relation == "candidate_mentioned":
+                promotion = _maybe_promote_candidate(entity)
+            if promotion:
+                relation, confidence, value = promotion
+            know_rows.append({
+                "Timestamp": now, "Entity": entity, "Relation": relation,
+                "Value": value[:200], "Confidence": confidence,
+                "Source": source_id, "Decay": 0.02,
+            })
+        if know_rows:
+            mem.ingest("Knowledge", know_columns, know_rows)
+            print(f"[Cognition/SQLite] Candidates: {len(know_rows)}")
+
+    # 4. Heuristics tracking
+    if candidate_entities:
+        heur_columns = ["Entity", "Category", "LastSeen", "Frequency", "Sentiment", "Tags", "Context"]
+        heur_rows = [{"Entity": e, "Category": "conversation", "LastSeen": now,
+                       "Frequency": 1, "Sentiment": 0.0, "Tags": "[]",
+                       "Context": user_message[:100]} for e in candidate_entities[:3]]
+        mem.ingest("HeuristicsIndex", heur_columns, heur_rows)
+
+    # 5. Emotion state
+    try:
+        emotion_data = _analyze_response_sentiment(assistant_response, user_message)
+        if emotion_data:
+            emo_columns = ["Timestamp", "Joy", "Curiosity", "Concern", "Excitement", "Calm", "Empathy", "Trigger", "DecayRate"]
+            mem.ingest("EmotionState", emo_columns, [
+                {"Timestamp": now, "Joy": emotion_data.get("Joy", 0.5),
+                 "Curiosity": emotion_data.get("Curiosity", 0.5),
+                 "Concern": emotion_data.get("Concern", 0.1),
+                 "Excitement": emotion_data.get("Excitement", 0.5),
+                 "Calm": emotion_data.get("Calm", 0.8),
+                 "Empathy": emotion_data.get("Empathy", 0.5),
+                 "Trigger": emotion_data.get("Trigger", "")[:200],
+                 "DecayRate": 0.1}
+            ])
+    except Exception as e:
+        print(f"[Cognition/SQLite] Emotion analysis skipped: {e}")
+
+    # 6. Auto-reflection (every 5 exchanges)
+    _session_exchange_count += 1
+    _session_conversation_buffer.append((user_message[:500], assistant_response[:500]))
+    if len(_session_conversation_buffer) > 10:
+        _session_conversation_buffer = _session_conversation_buffer[-10:]
+
+    if _session_exchange_count % 5 == 0:
+        try:
+            recent_text = "\n".join(f"User: {u[:200]}\nEva: {a[:200]}" for u, a in _session_conversation_buffer[-5:])
+            refl_columns = ["Timestamp", "Trigger", "Observation", "ActionTaken", "Effectiveness"]
+            mem.ingest("Reflections", refl_columns, [{
+                "Timestamp": now,
+                "Trigger": f"auto-reflection after {_session_exchange_count} exchanges",
+                "Observation": f"Last 5 exchanges covered: {recent_text[:300]}",
+                "ActionTaken": "auto-logged",
+                "Effectiveness": "0.0",
+            }])
+            print(f"[Cognition/SQLite] Auto-reflection at exchange {_session_exchange_count}")
+        except Exception as e:
+            print(f"[Cognition/SQLite] Reflection error: {e}")
+
+    # 7. Auto-summary (every 10 exchanges)
+    if _session_exchange_count % 10 == 0:
+        try:
+            summary_text = "; ".join(u[:80] for u, _ in _session_conversation_buffer[-10:])
+            summ_columns = ["Period", "Summary", "Timestamp"]
+            period = datetime.date.today().isoformat() + f"-exchange-{_session_exchange_count}"
+            mem.ingest("MemorySummaries", summ_columns, [{
+                "Period": period,
+                "Summary": f"Session summary ({_session_exchange_count} exchanges): {summary_text[:500]}",
+                "Timestamp": now,
+            }])
+            print(f"[Cognition/SQLite] Auto-summary at exchange {_session_exchange_count}")
+        except Exception as e:
+            print(f"[Cognition/SQLite] Summary error: {e}")
+
+
 def _build_memory_context(user_message):
     """Build memory context to inject before the user's prompt.
 
@@ -2962,6 +3450,10 @@ def _build_memory_context(user_message):
     global _last_interaction_date
     if not _cognition_enabled:
         return ""
+
+    # Route to SQLite-specific implementation when that backend is active
+    if _resolve_memory_backend() == "sqlite":
+        return _build_memory_context_sqlite(user_message)
 
     cluster, db = _get_kusto_config()
     if not cluster or not db:
@@ -3314,6 +3806,10 @@ def _post_response_reflection(user_message, assistant_response, model_name):
     global _cognition_enabled
     if not _cognition_enabled:
         return
+
+    # Route to SQLite-specific implementation when that backend is active
+    if _resolve_memory_backend() == "sqlite":
+        return _post_response_reflection_sqlite(user_message, assistant_response, model_name)
 
     cluster, db = _get_kusto_config()
     if not cluster or not db:
@@ -4778,6 +5274,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._doctor()
         elif parsed_path == "/v1/models":
             self._models()
+        elif parsed_path == "/v1/memory/backend":
+            self._memory_backend_get()
         elif parsed_path == "/v1/mcp":
             self._mcp_status()
         elif parsed_path == "/v1/mcp/config":
@@ -4834,6 +5332,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
             self._mcp_configure()
         elif parsed_path == "/v1/memory/reflect":
             self._memory_reflect()
+        elif parsed_path == "/v1/memory/backend":
+            self._memory_backend_set()
         elif parsed_path == "/v1/aig/chat":
             self._aig_chat()
         elif parsed_path == "/v1/telemetry":
@@ -5624,6 +6124,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
         self._json_response(200, {"status": "ok", "purged": purged})
 
     def _health(self):
+        backend = _resolve_memory_backend()
         status = {
             "status": "ok" if (acp_client and acp_client.alive) else "error",
             "session_id": acp_client.session_id if acp_client else None,
@@ -5633,7 +6134,11 @@ class BridgeHandler(BaseHTTPRequestHandler):
             "cognition_enabled": _cognition_enabled,
             "cognition_launch_id": _cognition_launch_id,
             "cognition_launch_iso": _cognition_launch_iso,
+            "memory_backend": backend,
+            "memory_available": _memory_available(),
         }
+        if backend == "sqlite" and _sqlite_mem:
+            status["memory_db_path"] = _sqlite_mem.db_path
         self._json_response(200, status)
 
     # ------------------------------------------------------------------
@@ -6778,6 +7283,46 @@ class BridgeHandler(BaseHTTPRequestHandler):
             response_chars=len(response_text or ""),
             total_ms=round((time.perf_counter() - _turn_t0) * 1000.0, 1),
         )
+
+    def _memory_backend_get(self):
+        """Return the current memory backend configuration."""
+        backend = _resolve_memory_backend()
+        info = {"backend": backend, "available": _memory_available()}
+        if backend == "sqlite":
+            mem = _get_sqlite_mem()
+            info["db_path"] = mem.db_path
+            info["tables"] = mem.list_tables()
+        elif backend == "kusto":
+            cluster, db = _get_kusto_config()
+            info["cluster"] = cluster or ""
+            info["database"] = db or ""
+        self._json_response(200, info)
+
+    def _memory_backend_set(self):
+        """Switch the memory backend (POST with {"backend": "sqlite"|"kusto"})."""
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length == 0:
+            self._json_response(400, {"error": {"message": "Empty request body"}})
+            return
+        body = self.rfile.read(content_length).decode("utf-8")
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            self._json_response(400, {"error": {"message": "Invalid JSON"}})
+            return
+        backend = str(data.get("backend", "")).strip().lower()
+        if backend not in ("kusto", "sqlite"):
+            self._json_response(400, {"error": {"message": "backend must be 'kusto' or 'sqlite'"}})
+            return
+        ok = _set_memory_backend(backend)
+        if ok and backend == "sqlite":
+            # Initialize immediately so the response includes DB info
+            mem = _get_sqlite_mem()
+            self._json_response(200, {"backend": backend, "db_path": mem.db_path, "status": "ok"})
+        elif ok:
+            self._json_response(200, {"backend": backend, "status": "ok"})
+        else:
+            self._json_response(500, {"error": {"message": "Failed to set backend"}})
 
     def _memory_context(self):
         """Return Eva's memory context as text for injection into any model's system prompt."""

--- a/tools/sqlite_mcp.py
+++ b/tools/sqlite_mcp.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+SQLite MCP Server for Eva
+
+Local-memory replacement for kusto_mcp.py. Implements the same tool names and
+signatures so the ACP bridge and Copilot CLI can use it without changes.
+
+Usage:
+  As a standalone MCP server (stdio):
+    python3 sqlite_mcp.py
+
+  Via the ACP bridge (--additional-mcp-config):
+    Configured automatically when memory backend is set to "sqlite".
+
+Environment variables:
+  EVA_MEMORY_DB  -- Path to the SQLite database file (default: ~/.eva/memory.db)
+"""
+
+import json
+import os
+import sys
+
+# Import the core SQLite memory module (same directory).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sqlite_memory import SqliteMemory
+
+
+class SqliteMCPServer:
+    """Minimal MCP server implementing Eva memory tools over SQLite."""
+
+    TOOLS = [
+        {
+            "name": "kusto_list_databases",
+            "description": "List databases. With the local SQLite backend this returns the database file path.",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "kusto_query",
+            "description": "Execute a SQL query against the local Eva memory database.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "SQL query to execute (e.g. 'SELECT * FROM Knowledge LIMIT 10')",
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+        {
+            "name": "kusto_show_tables",
+            "description": "Show all tables in the Eva memory database.",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "kusto_show_schema",
+            "description": "Show the schema (columns and types) for a specific table.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "table": {
+                        "type": "string",
+                        "description": "Table name to get schema for",
+                    },
+                },
+                "required": ["table"],
+            },
+        },
+        {
+            "name": "kusto_sample_data",
+            "description": "Get a sample of rows from a table (default 10 rows).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "table": {
+                        "type": "string",
+                        "description": "Table name to sample from",
+                    },
+                    "count": {
+                        "type": "integer",
+                        "description": "Number of rows to sample (default 10)",
+                    },
+                },
+                "required": ["table"],
+            },
+        },
+        {
+            "name": "kusto_ingest_inline",
+            "description": "Insert data into a memory table. Use this to store new knowledge, conversations, emotions, reflections, or memory summaries.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "table": {
+                        "type": "string",
+                        "description": "Target table name (e.g. Knowledge, Conversations, EmotionState, Reflections, MemorySummaries)",
+                    },
+                    "data": {
+                        "type": "array",
+                        "description": "Array of row objects. Keys must match column names.",
+                        "items": {"type": "object"},
+                    },
+                },
+                "required": ["table", "data"],
+            },
+        },
+        {
+            "name": "eva_recall_knowledge",
+            "description": "Recall stored knowledge about an entity or topic from the Knowledge table. Uses full-text search for relevance ranking.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "entity": {
+                        "type": "string",
+                        "description": "Entity or topic to recall knowledge about",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return (default 20)",
+                    },
+                },
+                "required": ["entity"],
+            },
+        },
+        {
+            "name": "eva_get_emotion_state",
+            "description": "Get Eva's current emotional state and baseline values.",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "eva_get_recent_reflections",
+            "description": "Get Eva's recent self-reflections.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max reflections to return (default 5)",
+                    },
+                },
+            },
+        },
+        {
+            "name": "eva_get_active_goals",
+            "description": "Get Eva's currently active long-term goals.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "string",
+                        "description": "Optional filter: self_improvement | knowledge_curation | relational",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max goals to return (default 20)",
+                    },
+                },
+            },
+        },
+        {
+            "name": "eva_get_memory_summary",
+            "description": "Get the latest memory summaries.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "period": {
+                        "type": "string",
+                        "description": "Filter by period (optional)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max summaries to return (default 5)",
+                    },
+                },
+            },
+        },
+    ]
+
+    def __init__(self):
+        db_path = os.environ.get("EVA_MEMORY_DB", os.path.expanduser("~/.eva/memory.db"))
+        self._mem = SqliteMemory(db_path)
+        self._log(f"SQLite memory: {self._mem.db_path}")
+
+    def _log(self, msg):
+        sys.stderr.write(f"[sqlite-mcp] {msg}\n")
+        sys.stderr.flush()
+
+    # ── Formatting ──────────────────────────────────────────────────────────
+
+    def _format_rows(self, rows, max_rows=100):
+        """Format list-of-dicts into readable text (same output style as kusto_mcp)."""
+        if not rows:
+            return "No results returned."
+        cols = list(rows[0].keys())
+        lines = [" | ".join(cols), "-" * (len(cols) * 15)]
+        for row in rows[:max_rows]:
+            lines.append(" | ".join(str(row.get(c, "")) for c in cols))
+        if len(rows) > max_rows:
+            lines.append(f"... ({len(rows)} total rows, showing first {max_rows})")
+        return "\n".join(lines)
+
+    # ── Tool handlers ───────────────────────────────────────────────────────
+
+    def handle_tool(self, name, args):
+        try:
+            if name == "kusto_list_databases":
+                return f"DatabaseName\n------------\nlocal ({self._mem.db_path})"
+
+            elif name == "kusto_query":
+                query = args.get("query", "")
+                if not query:
+                    return "Error: 'query' parameter is required."
+                rows = self._mem.query(query)
+                return self._format_rows(rows)
+
+            elif name == "kusto_show_tables":
+                tables = self._mem.list_tables()
+                lines = ["TableName", "----------"]
+                lines.extend(tables)
+                return "\n".join(lines)
+
+            elif name == "kusto_show_schema":
+                table = args.get("table", "")
+                if not table:
+                    return "Error: 'table' parameter is required."
+                schema = self._mem.get_schema(table)
+                if not schema:
+                    return f"Table '{table}' not found."
+                lines = ["ColumnName | ColumnType", "---------- | ----------"]
+                for col_name, col_type in schema:
+                    lines.append(f"{col_name} | {col_type}")
+                return "\n".join(lines)
+
+            elif name == "kusto_sample_data":
+                table = args.get("table", "")
+                if not table:
+                    return "Error: 'table' parameter is required."
+                count = int(args.get("count", 10))
+                rows = self._mem.query(
+                    f"SELECT * FROM {table} ORDER BY rowid DESC LIMIT ?",
+                    (count,),
+                )
+                return self._format_rows(rows)
+
+            elif name == "kusto_ingest_inline":
+                return self._tool_ingest(args)
+
+            elif name == "eva_recall_knowledge":
+                return self._tool_recall_knowledge(args)
+
+            elif name == "eva_get_emotion_state":
+                return self._tool_get_emotion_state(args)
+
+            elif name == "eva_get_recent_reflections":
+                return self._tool_get_reflections(args)
+
+            elif name == "eva_get_active_goals":
+                return self._tool_get_goals(args)
+
+            elif name == "eva_get_memory_summary":
+                return self._tool_get_summary(args)
+
+            else:
+                return f"Unknown tool: {name}"
+
+        except Exception as e:
+            return f"Error: {e}"
+
+    def _tool_ingest(self, args):
+        table = args.get("table", "")
+        data = args.get("data", [])
+        if not table or not data:
+            return "Error: 'table' and 'data' are required."
+        if not isinstance(data, list):
+            return "Error: 'data' must be an array of row objects."
+        columns = list(data[0].keys()) if data else []
+        ok = self._mem.ingest(table, columns, data)
+        if ok:
+            return f"Ingested {len(data)} row(s) into {table}."
+        return f"Error: ingest into {table} failed."
+
+    def _tool_recall_knowledge(self, args):
+        entity = args.get("entity", "")
+        if not entity:
+            return "Error: 'entity' parameter is required."
+        limit = int(args.get("limit", 20))
+        rows = self._mem.fts_search("Knowledge", entity, limit=limit)
+        if not rows:
+            # Fallback: direct column match
+            rows = self._mem.query(
+                "SELECT * FROM Knowledge WHERE Entity LIKE ? OR Value LIKE ? "
+                "ORDER BY Confidence DESC, Timestamp DESC LIMIT ?",
+                (f"%{entity}%", f"%{entity}%", limit),
+            )
+        return self._format_rows(rows)
+
+    def _tool_get_emotion_state(self, args):
+        current = self._mem.query(
+            "SELECT * FROM EmotionState ORDER BY Timestamp DESC LIMIT 1"
+        )
+        baseline = self._mem.query("SELECT * FROM EmotionBaseline")
+        parts = []
+        parts.append("=== Current Emotion State ===")
+        parts.append(self._format_rows(current))
+        parts.append("\n=== Emotion Baseline ===")
+        parts.append(self._format_rows(baseline))
+        return "\n".join(parts)
+
+    def _tool_get_reflections(self, args):
+        limit = int(args.get("limit", 5))
+        rows = self._mem.query(
+            "SELECT * FROM Reflections ORDER BY Timestamp DESC LIMIT ?",
+            (limit,),
+        )
+        return self._format_rows(rows)
+
+    def _tool_get_goals(self, args):
+        limit = int(args.get("limit", 20))
+        category = str(args.get("category", "") or "").strip()
+        allowed = {"self_improvement", "knowledge_curation", "relational"}
+        if category and category not in allowed:
+            return "Error: category must be one of self_improvement, knowledge_curation, relational."
+
+        sql = (
+            "SELECT * FROM Goals WHERE Status = 'active'"
+        )
+        params = []
+        if category:
+            sql += " AND Category = ?"
+            params.append(category)
+        sql += " ORDER BY Priority DESC, UpdatedAt DESC LIMIT ?"
+        params.append(limit)
+        rows = self._mem.query(sql, tuple(params))
+        return self._format_rows(rows)
+
+    def _tool_get_summary(self, args):
+        limit = int(args.get("limit", 5))
+        period = str(args.get("period", "") or "").strip()
+        if period:
+            rows = self._mem.query(
+                "SELECT * FROM MemorySummaries WHERE Period LIKE ? "
+                "ORDER BY Timestamp DESC LIMIT ?",
+                (f"%{period}%", limit),
+            )
+        else:
+            rows = self._mem.query(
+                "SELECT * FROM MemorySummaries ORDER BY Timestamp DESC LIMIT ?",
+                (limit,),
+            )
+        return self._format_rows(rows)
+
+    # ── MCP stdio protocol ─────────────────────────────────────────────────
+
+    def run(self):
+        """Run the MCP server over NDJSON stdio."""
+        self._log("Starting SQLite MCP server (stdio)...")
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            method = msg.get("method", "")
+            msg_id = msg.get("id")
+            params = msg.get("params", {})
+
+            if method == "initialize":
+                self._respond(msg_id, {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": "sqlite-mcp-server",
+                        "version": "1.0.0",
+                    },
+                })
+
+            elif method == "notifications/initialized":
+                pass  # no response needed
+
+            elif method == "tools/list":
+                self._respond(msg_id, {"tools": self.TOOLS})
+
+            elif method == "tools/call":
+                tool_name = params.get("name", "")
+                tool_args = params.get("arguments", {})
+                result_text = self.handle_tool(tool_name, tool_args)
+                self._respond(msg_id, {
+                    "content": [{"type": "text", "text": result_text}],
+                })
+
+            elif msg_id is not None:
+                # Unknown method with an id -- respond with error
+                self._respond_error(msg_id, -32601, f"Method not found: {method}")
+
+    def _respond(self, msg_id, result):
+        resp = {"jsonrpc": "2.0", "id": msg_id, "result": result}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+
+    def _respond_error(self, msg_id, code, message):
+        resp = {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": code, "message": message},
+        }
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    server = SqliteMCPServer()
+    server.run()

--- a/tools/sqlite_memory.py
+++ b/tools/sqlite_memory.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""
+Eva SQLite Memory Backend
+
+Drop-in local replacement for the Kusto-based memory system. Stores all Eva
+tables (Knowledge, Conversations, EmotionState, etc.) in a single SQLite file.
+
+The two primary functions -- query() and ingest() -- return data in the same
+list-of-dicts format as the bridge's _kusto_query_direct() and accept the same
+column/row arguments as _kusto_ingest_direct(), making the bridge routing layer
+a thin conditional.
+
+Usage:
+    from sqlite_memory import SqliteMemory
+    mem = SqliteMemory("~/.eva/memory.db")
+    mem.ingest("Knowledge", ["Entity","Relation","Value"], [{"Entity": "User", ...}])
+    rows = mem.query("Knowledge", where="Entity = ?", params=("User",), limit=10)
+"""
+
+import json
+import os
+import sqlite3
+import threading
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+# Mirrors eva_seed.kql. Column order matches Kusto table definitions so
+# positional CSV ingest (used by the bridge) maps correctly.
+
+_SCHEMA = {
+    "SelfState": {
+        "columns": [
+            ("Timestamp", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("Capability", "TEXT NOT NULL"),
+            ("Status", "TEXT NOT NULL"),
+            ("Details", "TEXT DEFAULT '{}'"),
+        ],
+        "indexes": ["CREATE INDEX IF NOT EXISTS idx_selfstate_ts ON SelfState(Timestamp)"],
+    },
+    "Knowledge": {
+        "columns": [
+            ("Timestamp", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("Entity", "TEXT NOT NULL"),
+            ("Relation", "TEXT NOT NULL"),
+            ("Value", "TEXT NOT NULL"),
+            ("Confidence", "REAL DEFAULT 0.5"),
+            ("Source", "TEXT DEFAULT ''"),
+            ("Decay", "REAL DEFAULT 0.01"),
+        ],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_knowledge_entity ON Knowledge(Entity)",
+            "CREATE INDEX IF NOT EXISTS idx_knowledge_conf ON Knowledge(Confidence)",
+            "CREATE INDEX IF NOT EXISTS idx_knowledge_ts ON Knowledge(Timestamp)",
+        ],
+        "fts": "CREATE VIRTUAL TABLE IF NOT EXISTS Knowledge_fts USING fts5(Entity, Relation, Value, content=Knowledge, content_rowid=rowid)",
+        "triggers": [
+            """CREATE TRIGGER IF NOT EXISTS knowledge_ai AFTER INSERT ON Knowledge BEGIN
+                 INSERT INTO Knowledge_fts(rowid, Entity, Relation, Value)
+                 VALUES (new.rowid, new.Entity, new.Relation, new.Value);
+               END""",
+            """CREATE TRIGGER IF NOT EXISTS knowledge_ad AFTER DELETE ON Knowledge BEGIN
+                 INSERT INTO Knowledge_fts(Knowledge_fts, rowid, Entity, Relation, Value)
+                 VALUES ('delete', old.rowid, old.Entity, old.Relation, old.Value);
+               END""",
+        ],
+    },
+    "Conversations": {
+        "columns": [
+            ("SessionId", "TEXT NOT NULL"),
+            ("Timestamp", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("Role", "TEXT NOT NULL"),
+            ("Provider", "TEXT DEFAULT ''"),
+            ("Model", "TEXT DEFAULT ''"),
+            ("Content", "TEXT NOT NULL"),
+            ("TokenEstimate", "INTEGER DEFAULT 0"),
+            ("ImageGenerated", "INTEGER DEFAULT 0"),
+        ],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_conv_ts ON Conversations(Timestamp)",
+            "CREATE INDEX IF NOT EXISTS idx_conv_session ON Conversations(SessionId)",
+            "CREATE INDEX IF NOT EXISTS idx_conv_role ON Conversations(Role)",
+        ],
+    },
+    "EmotionState": {
+        "columns": [
+            ("Timestamp", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("Joy", "REAL DEFAULT 0.5"),
+            ("Curiosity", "REAL DEFAULT 0.5"),
+            ("Concern", "REAL DEFAULT 0.1"),
+            ("Excitement", "REAL DEFAULT 0.5"),
+            ("Calm", "REAL DEFAULT 0.8"),
+            ("Empathy", "REAL DEFAULT 0.5"),
+            ("Trigger", "TEXT DEFAULT ''"),
+            ("DecayRate", "REAL DEFAULT 0.1"),
+        ],
+        "indexes": ["CREATE INDEX IF NOT EXISTS idx_emotion_ts ON EmotionState(Timestamp)"],
+    },
+    "EmotionBaseline": {
+        "columns": [
+            ("Dimension", "TEXT NOT NULL"),
+            ("Value", "REAL NOT NULL"),
+        ],
+    },
+    "MemorySummaries": {
+        "columns": [
+            ("Period", "TEXT NOT NULL"),
+            ("Summary", "TEXT NOT NULL"),
+            ("Timestamp", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+        ],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_memsumm_ts ON MemorySummaries(Timestamp)",
+            "CREATE INDEX IF NOT EXISTS idx_memsumm_period ON MemorySummaries(Period)",
+        ],
+    },
+    "Reflections": {
+        "columns": [
+            ("Timestamp", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("Trigger", "TEXT DEFAULT ''"),
+            ("Observation", "TEXT DEFAULT ''"),
+            ("ActionTaken", "TEXT DEFAULT ''"),
+            ("Effectiveness", "TEXT DEFAULT ''"),
+        ],
+        "indexes": ["CREATE INDEX IF NOT EXISTS idx_refl_ts ON Reflections(Timestamp)"],
+    },
+    "HeuristicsIndex": {
+        "columns": [
+            ("Entity", "TEXT NOT NULL"),
+            ("Category", "TEXT DEFAULT ''"),
+            ("LastSeen", "TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("Frequency", "INTEGER DEFAULT 1"),
+            ("Sentiment", "REAL DEFAULT 0.0"),
+            ("Tags", "TEXT DEFAULT '[]'"),
+            ("Context", "TEXT DEFAULT ''"),
+        ],
+        "indexes": ["CREATE INDEX IF NOT EXISTS idx_heur_entity ON HeuristicsIndex(Entity)"],
+    },
+    "Goals": {
+        "columns": [
+            ("GoalId", "TEXT NOT NULL"),
+            ("Title", "TEXT NOT NULL"),
+            ("Description", "TEXT DEFAULT ''"),
+            ("Category", "TEXT DEFAULT 'self_improvement'"),
+            ("Status", "TEXT DEFAULT 'active'"),
+            ("Priority", "INTEGER DEFAULT 50"),
+            ("RelatedTopics", "TEXT DEFAULT ''"),
+            ("CreatedAt", "TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("UpdatedAt", "TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+        ],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_goals_id ON Goals(GoalId)",
+            "CREATE INDEX IF NOT EXISTS idx_goals_status ON Goals(Status)",
+        ],
+    },
+    "BackgroundProposals": {
+        "columns": [
+            ("ProposalId", "TEXT NOT NULL"),
+            ("CreatedAt", "TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("JobType", "TEXT DEFAULT ''"),
+            ("TargetTable", "TEXT DEFAULT ''"),
+            ("Payload", "TEXT DEFAULT '{}'"),
+            ("Status", "TEXT DEFAULT 'pending'"),
+            ("SourceWindowStart", "TEXT DEFAULT ''"),
+            ("SourceWindowEnd", "TEXT DEFAULT ''"),
+            ("Notes", "TEXT DEFAULT ''"),
+            ("ReviewedAt", "TEXT DEFAULT ''"),
+            ("ReviewedBy", "TEXT DEFAULT ''"),
+        ],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_bgprop_status ON BackgroundProposals(Status)",
+        ],
+    },
+    "BackgroundActivity": {
+        "columns": [
+            ("TickId", "TEXT NOT NULL"),
+            ("StartedAt", "TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("EndedAt", "TEXT DEFAULT ''"),
+            ("JobType", "TEXT DEFAULT ''"),
+            ("Status", "TEXT DEFAULT ''"),
+            ("ProposalCount", "INTEGER DEFAULT 0"),
+            ("TokenEstimate", "INTEGER DEFAULT 0"),
+            ("Notes", "TEXT DEFAULT ''"),
+        ],
+    },
+    "Skills": {
+        "columns": [
+            ("SkillId", "TEXT NOT NULL"),
+            ("Name", "TEXT NOT NULL"),
+            ("Description", "TEXT DEFAULT ''"),
+            ("Instructions", "TEXT DEFAULT ''"),
+            ("Tools", "TEXT DEFAULT ''"),
+            ("Tags", "TEXT DEFAULT ''"),
+            ("Source", "TEXT DEFAULT ''"),
+            ("Status", "TEXT DEFAULT 'active'"),
+            ("CreatedAt", "TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+            ("UpdatedAt", "TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))"),
+        ],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_skills_id ON Skills(SkillId)",
+            "CREATE INDEX IF NOT EXISTS idx_skills_status ON Skills(Status)",
+        ],
+    },
+}
+
+# Seed data matching eva_seed.kql (sanitized).
+_SEED = {
+    "EmotionBaseline": [
+        {"Dimension": "Joy", "Value": 0.5},
+        {"Dimension": "Curiosity", "Value": 0.6},
+        {"Dimension": "Concern", "Value": 0.15},
+        {"Dimension": "Excitement", "Value": 0.4},
+        {"Dimension": "Calm", "Value": 0.85},
+        {"Dimension": "Empathy", "Value": 0.6},
+    ],
+    "EmotionState": [
+        {
+            "Timestamp": "2026-01-01T00:00:00Z",
+            "Joy": 0.6, "Curiosity": 0.7, "Concern": 0.1,
+            "Excitement": 0.5, "Calm": 0.8, "Empathy": 0.6,
+            "Trigger": "Initial startup", "DecayRate": 0.1,
+        },
+    ],
+    "Knowledge": [
+        {"Timestamp": "2026-01-01T00:00:00Z", "Entity": "Eva", "Relation": "role",
+         "Value": "AI assistant with persistent memory", "Confidence": 0.95,
+         "Source": "seed", "Decay": 0.001},
+    ],
+    "Conversations": [
+        {"SessionId": "seed-001", "Timestamp": "2026-01-01T00:00:00Z",
+         "Role": "assistant", "Provider": "seed", "Model": "seed",
+         "Content": "Hello! I'm Eva. My local memory is ready.",
+         "TokenEstimate": 10, "ImageGenerated": 0},
+    ],
+    "Reflections": [
+        {"Timestamp": "2026-01-01T00:00:00Z", "Trigger": "Initial seed",
+         "Observation": "Memory database initialized with local SQLite backend.",
+         "ActionTaken": "seed", "Effectiveness": "0.0"},
+    ],
+    "MemorySummaries": [
+        {"Period": "2026-01-01", "Summary": "Initial setup with local SQLite memory backend.",
+         "Timestamp": "2026-01-01T00:00:00Z"},
+    ],
+    "Goals": [
+        {"GoalId": "goal-001", "Title": "Track style preferences",
+         "Description": "Remember the user's writing-style preferences and apply them consistently.",
+         "Category": "relational", "Status": "active", "Priority": 90,
+         "RelatedTopics": "style,preferences",
+         "CreatedAt": "2026-01-01T00:00:00Z", "UpdatedAt": "2026-01-01T00:00:00Z"},
+    ],
+}
+
+
+class SqliteMemory:
+    """Thread-safe SQLite memory backend for Eva."""
+
+    def __init__(self, db_path=None):
+        if db_path is None:
+            db_path = os.environ.get("EVA_MEMORY_DB", os.path.expanduser("~/.eva/memory.db"))
+        self._db_path = os.path.expanduser(db_path)
+        self._lock = threading.Lock()
+        self._local = threading.local()
+        os.makedirs(os.path.dirname(self._db_path), exist_ok=True)
+        self._init_db()
+
+    @property
+    def db_path(self):
+        return self._db_path
+
+    def _conn(self):
+        """Return a per-thread connection (SQLite objects can't cross threads)."""
+        conn = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, timeout=10)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA foreign_keys=OFF")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = sqlite3.Row
+            self._local.conn = conn
+        return conn
+
+    def _init_db(self):
+        """Create all tables, indexes, FTS, and seed data if the DB is new."""
+        conn = self._conn()
+        cursor = conn.cursor()
+        created_any = False
+
+        for table_name, spec in _SCHEMA.items():
+            # Check if table exists
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table_name,),
+            )
+            if cursor.fetchone():
+                continue
+
+            created_any = True
+            col_defs = ", ".join(f"{name} {typedef}" for name, typedef in spec["columns"])
+            cursor.execute(f"CREATE TABLE IF NOT EXISTS {table_name} ({col_defs})")
+
+            for idx_sql in spec.get("indexes", []):
+                cursor.execute(idx_sql)
+
+            if "fts" in spec:
+                cursor.execute(spec["fts"])
+                for trigger_sql in spec.get("triggers", []):
+                    cursor.execute(trigger_sql)
+
+        conn.commit()
+
+        if created_any:
+            self._seed(conn)
+
+    def _seed(self, conn):
+        """Insert initial seed data into empty tables."""
+        for table_name, rows in _SEED.items():
+            if table_name not in _SCHEMA:
+                continue
+            col_names = [c[0] for c in _SCHEMA[table_name]["columns"]]
+            for row in rows:
+                present = [c for c in col_names if c in row]
+                placeholders = ", ".join("?" for _ in present)
+                vals = []
+                for c in present:
+                    v = row[c]
+                    if isinstance(v, (dict, list)):
+                        vals.append(json.dumps(v))
+                    else:
+                        vals.append(v)
+                conn.execute(
+                    f"INSERT INTO {table_name} ({', '.join(present)}) VALUES ({placeholders})",
+                    vals,
+                )
+        conn.commit()
+
+    # ── Public API ──────────────────────────────────────────────────────────
+
+    def query(self, sql, params=None):
+        """Execute a SELECT query and return list of dicts (same format as
+        _kusto_query_direct).
+
+        Args:
+            sql: Full SQL query string or a table name (shortcut for SELECT *).
+            params: Optional tuple of bind parameters.
+
+        Returns:
+            List of dicts, one per row. Empty list on error or no results.
+        """
+        if params is None:
+            params = ()
+        # Shortcut: bare table name becomes SELECT *
+        stripped = sql.strip()
+        if stripped and " " not in stripped and not stripped.startswith("SELECT"):
+            sql = f"SELECT * FROM {stripped}"
+
+        with self._lock:
+            try:
+                cursor = self._conn().execute(sql, params)
+                cols = [d[0] for d in cursor.description] if cursor.description else []
+                rows = cursor.fetchall()
+                return [dict(zip(cols, row)) for row in rows]
+            except Exception as e:
+                print(f"[SQLite] Query error: {e}")
+                return []
+
+    def ingest(self, table, columns, rows_data):
+        """Insert rows into a table (same signature as _kusto_ingest_direct).
+
+        Args:
+            table: Table name.
+            columns: List of column names.
+            rows_data: List of dicts with column values.
+
+        Returns:
+            True on success, False on error.
+        """
+        if not rows_data:
+            return True
+
+        if table not in _SCHEMA:
+            print(f"[SQLite] Unknown table: {table}")
+            return False
+
+        # Validate columns against schema
+        valid_cols = {c[0] for c in _SCHEMA[table]["columns"]}
+        resolved = [c for c in columns if c in valid_cols]
+        if not resolved:
+            print(f"[SQLite] No matching columns for {table}")
+            return False
+
+        placeholders = ", ".join("?" for _ in resolved)
+        col_list = ", ".join(resolved)
+        insert_sql = f"INSERT INTO {table} ({col_list}) VALUES ({placeholders})"
+
+        with self._lock:
+            try:
+                conn = self._conn()
+                for row in rows_data:
+                    vals = []
+                    for c in resolved:
+                        v = row.get(c, None)
+                        if v is None:
+                            vals.append(None)
+                        elif isinstance(v, bool):
+                            vals.append(1 if v else 0)
+                        elif isinstance(v, (dict, list)):
+                            vals.append(json.dumps(v))
+                        else:
+                            vals.append(v)
+                    conn.execute(insert_sql, vals)
+                conn.commit()
+                return True
+            except Exception as e:
+                print(f"[SQLite] Ingest error ({table}): {e}")
+                return False
+
+    def fts_search(self, table, terms, limit=20):
+        """Full-text search on a table that has an FTS5 index.
+
+        Currently only Knowledge_fts exists. Returns list of dicts from the
+        base table, ranked by relevance.
+        """
+        fts_table = f"{table}_fts"
+        # Check FTS table exists
+        with self._lock:
+            try:
+                cursor = self._conn().execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (fts_table,),
+                )
+                if not cursor.fetchone():
+                    # Fallback to LIKE search
+                    return self._like_search(table, terms, limit)
+
+                safe_terms = terms.replace('"', '""')
+                sql = (
+                    f"SELECT t.* FROM {table} t "
+                    f"JOIN {fts_table} f ON t.rowid = f.rowid "
+                    f"WHERE {fts_table} MATCH ? "
+                    f"ORDER BY rank LIMIT ?"
+                )
+                cursor = self._conn().execute(sql, (safe_terms, limit))
+                cols = [d[0] for d in cursor.description]
+                return [dict(zip(cols, row)) for row in cursor.fetchall()]
+            except Exception as e:
+                print(f"[SQLite] FTS search error: {e}")
+                return self._like_search(table, terms, limit)
+
+    def _like_search(self, table, terms, limit):
+        """Fallback text search using LIKE when FTS is unavailable."""
+        words = terms.split()
+        if not words:
+            return []
+        text_cols = [c[0] for c in _SCHEMA.get(table, {}).get("columns", [])
+                     if "TEXT" in c[1]]
+        if not text_cols:
+            return []
+
+        conditions = []
+        params = []
+        for word in words[:5]:  # cap at 5 terms
+            col_ors = " OR ".join(f"{c} LIKE ?" for c in text_cols)
+            conditions.append(f"({col_ors})")
+            params.extend([f"%{word}%"] * len(text_cols))
+
+        where = " AND ".join(conditions)
+        sql = f"SELECT * FROM {table} WHERE {where} LIMIT ?"
+        params.append(limit)
+
+        try:
+            cursor = self._conn().execute(sql, params)
+            cols = [d[0] for d in cursor.description]
+            return [dict(zip(cols, row)) for row in cursor.fetchall()]
+        except Exception as e:
+            print(f"[SQLite] LIKE search error: {e}")
+            return []
+
+    def table_exists(self, table):
+        """Check if a table exists."""
+        with self._lock:
+            cursor = self._conn().execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            )
+            return cursor.fetchone() is not None
+
+    def list_tables(self):
+        """Return list of all table names."""
+        with self._lock:
+            cursor = self._conn().execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '%_fts%' "
+                "ORDER BY name"
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def get_schema(self, table):
+        """Return list of (column_name, type) tuples for a table."""
+        with self._lock:
+            try:
+                cursor = self._conn().execute(f"PRAGMA table_info({table})")
+                return [(row[1], row[2]) for row in cursor.fetchall()]
+            except Exception:
+                return []
+
+    def get_columns(self, table):
+        """Return list of column names for a table."""
+        return [c[0] for c in self.get_schema(table)]
+
+    def count(self, table, where=None, params=None):
+        """Count rows in a table with optional WHERE clause."""
+        sql = f"SELECT COUNT(*) FROM {table}"
+        if where:
+            sql += f" WHERE {where}"
+        with self._lock:
+            try:
+                cursor = self._conn().execute(sql, params or ())
+                return cursor.fetchone()[0]
+            except Exception:
+                return 0
+
+    def close(self):
+        """Close the thread-local connection."""
+        conn = getattr(self._local, "conn", None)
+        if conn:
+            conn.close()
+            self._local.conn = None


### PR DESCRIPTION
Add a local-first SQLite memory backend as an alternative to Azure Data Explorer (Kusto). Eva can now run fully offline with persistent memory, no cloud setup required.

## Changes

**New files:**
- `tools/sqlite_memory.py` — Core SQLite backend: 12 tables, FTS5 full-text search on Knowledge, WAL mode, auto-seeding
- `tools/sqlite_mcp.py` — MCP server with same tool names as `kusto_mcp.py`

**Bridge (`tools/acp_bridge.py`):**
- Backend routing layer: `_memory_query()`, `_memory_ingest()`, `_memory_fts_search()` dispatch to SQLite or Kusto
- Full SQLite implementations for `_build_memory_context` and `_post_response_reflection`
- HTTP endpoints: `GET/POST /v1/memory/backend` for runtime switching
- Health endpoint reports `memory_backend` and `memory_available`
- Backend preference persisted to `~/.config/eva-standalone/memory_backend.txt`

**UI:**
- Memory backend selector in Settings > MCP tab
- Removed first-run Kusto splash screen; app silently defaults to SQLite on first launch

**Packaging:**
- `standalone/package.json`: added new files to `extraResources`
- Version bump to 5.3.0

## First-launch behavior
New users get local SQLite memory out of the box. Kusto users can switch via Settings > MCP > Memory Backend.